### PR TITLE
fix(deps): resolve pdfjs-dist version mismatch breaking OCR fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,11 @@
     "node": ">=24",
     "pnpm": ">=9"
   },
+  "pnpm": {
+    "overrides": {
+      "pdfjs-dist": "5.4.296"
+    }
+  },
   "files": [
     "dist",
     "README.md",
@@ -53,7 +58,7 @@
   "dependencies": {
     "@happyvertical/ocr": "^0.60.4",
     "@happyvertical/utils": "^0.60.2",
-    "pdf-to-png-converter": "^3.11.0",
+    "pdf-to-png-converter": "^3.10.0",
     "unpdf": "^1.4.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  pdfjs-dist: 5.4.296
+
 importers:
 
   .:
@@ -15,7 +18,7 @@ importers:
         specifier: ^0.60.2
         version: 0.60.2
       pdf-to-png-converter:
-        specifier: ^3.11.0
+        specifier: ^3.10.0
         version: 3.11.0
       unpdf:
         specifier: ^1.4.0
@@ -1828,8 +1831,8 @@ packages:
     resolution: {integrity: sha512-9V4seNenywRMGKX2AQX2IHdxUxTBffqfGNtozQjx2RokePG/TjvwABGfr7tozmWkmc4oAsO2q2RL6lFp5Bqxhw==}
     engines: {node: '>=20'}
 
-  pdfjs-dist@5.4.449:
-    resolution: {integrity: sha512-CegnUaT0QwAyQMS+7o2POr4wWUNNe8VaKKlcuoRHeYo98cVnqPpwOXNSx6Trl6szH02JrRcsPgletV6GmF3LtQ==}
+  pdfjs-dist@5.4.296:
+    resolution: {integrity: sha512-DlOzet0HO7OEnmUmB6wWGJrrdvbyJKftI1bhMitK7O2N8W2gc757yyYBbINy9IDafXAV9wmKr9t7xsTaNKRG5Q==}
     engines: {node: '>=20.16.0 || >=22.3.0'}
 
   picocolors@1.1.1:
@@ -3890,9 +3893,9 @@ snapshots:
   pdf-to-png-converter@3.11.0:
     dependencies:
       '@napi-rs/canvas': 0.1.84
-      pdfjs-dist: 5.4.449
+      pdfjs-dist: 5.4.296
 
-  pdfjs-dist@5.4.449:
+  pdfjs-dist@5.4.296:
     optionalDependencies:
       '@napi-rs/canvas': 0.1.84
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,11 @@
 {
-  "extends": ["local>happyvertical/renovate-config:default"]
+  "extends": ["local>happyvertical/renovate-config:default"],
+  "packageRules": [
+    {
+      "description": "Group PDF processing deps - pdfjs-dist must match version bundled in unpdf",
+      "groupName": "pdf processing (requires version sync)",
+      "matchPackageNames": ["unpdf", "pdf-to-png-converter", "pdfjs-dist"],
+      "dependencyDashboardApproval": true
+    }
+  ]
 }

--- a/src/extraction.test.ts
+++ b/src/extraction.test.ts
@@ -6,52 +6,59 @@ import type { PDFReader } from './shared/types';
 
 describe('PDF Content Extraction', () => {
   let reader: PDFReader;
+  let pdfPath: string;
 
   beforeEach(async () => {
     reader = await getPDFReader();
+    pdfPath = join(
+      fileURLToPath(new URL('.', import.meta.url)),
+      '..',
+      'test',
+      'Signed-Meeting-Minutes-October-8-2024-Regular-Council-Meeting-1.pdf',
+    );
   });
 
-  it('should extract text from a real PDF file', async () => {
-    const pdfPath = join(
-      fileURLToPath(new URL('.', import.meta.url)),
-      '..',
-      'test',
-      'Signed-Meeting-Minutes-October-8-2024-Regular-Council-Meeting-1.pdf',
-    );
-
-    const text = await reader.extractText(pdfPath);
-
-    // Should return string or null, never undefined or throw
-    expect(text !== undefined).toBe(true);
-    expect(typeof text === 'string' || text === null).toBe(true);
-  }, 60000); // 60 second timeout for OCR processing
-
   it('should extract metadata from PDF', async () => {
-    const pdfPath = join(
-      fileURLToPath(new URL('.', import.meta.url)),
-      '..',
-      'test',
-      'Signed-Meeting-Minutes-October-8-2024-Regular-Council-Meeting-1.pdf',
-    );
-
     const metadata = await reader.extractMetadata(pdfPath);
 
     expect(metadata).toBeDefined();
-    expect(typeof metadata.pageCount).toBe('number');
-    expect(metadata.pageCount).toBeGreaterThan(0);
-  }, 60000);
+    expect(metadata.pageCount).toBe(3);
+  });
 
-  it('should extract images from PDF', async () => {
-    const pdfPath = join(
-      fileURLToPath(new URL('.', import.meta.url)),
-      '..',
-      'test',
-      'Signed-Meeting-Minutes-October-8-2024-Regular-Council-Meeting-1.pdf',
-    );
+  it('should analyze PDF and detect it requires OCR', async () => {
+    const info = await reader.getInfo(pdfPath);
 
+    expect(info.pageCount).toBe(3);
+    expect(info.hasEmbeddedText).toBe(false);
+    expect(info.ocrRequired).toBe(true);
+    expect(info.recommendedStrategy).toBe('ocr');
+  });
+
+  it('should extract images from scanned PDF', async () => {
     const images = await reader.extractImages(pdfPath);
 
-    expect(Array.isArray(images)).toBe(true);
-    // Images may be empty array, that's fine
+    // Scanned PDF should have embedded images (one per page)
+    expect(images.length).toBe(3);
+
+    // Each image should have valid data
+    for (const image of images) {
+      expect(image.data).toBeDefined();
+      expect(image.width).toBeGreaterThan(0);
+      expect(image.height).toBeGreaterThan(0);
+    }
+  });
+
+  it('should extract text from scanned PDF via OCR fallback', async () => {
+    const text = await reader.extractText(pdfPath);
+
+    // Must successfully extract text, not return null
+    expect(text).not.toBeNull();
+    expect(typeof text).toBe('string');
+
+    // Must extract meaningful content from 3-page document
+    expect(text!.length).toBeGreaterThan(100);
+
+    // Should contain "Bentley" (the town name in the document)
+    expect(text!.toLowerCase()).toContain('bentley');
   }, 60000);
 });


### PR DESCRIPTION
## Summary

Fixes the pdfjs-dist version mismatch that broke OCR fallback for scanned PDFs.

- **Root cause**: `pdf-to-png-converter` used pdfjs-dist 5.4.449, but `unpdf` bundles 5.4.296 internally, causing version conflict errors
- **Fix**: Pin pdfjs-dist to 5.4.296 via pnpm override to match unpdf's bundled version
- **Tests**: Fixed tests that previously passed while OCR was broken - now they assert meaningful text extraction

## Changes

- Pin `pdfjs-dist` to `5.4.296` via pnpm override
- Downgrade `pdf-to-png-converter` to `^3.10.0` (compatible with 5.4.296)
- Fix extraction tests to assert OCR actually extracts >100 chars containing "bentley"
- Add Renovate config to group PDF deps and require approval for updates

## Test plan

- [x] `pnpm test` passes locally (41 tests)
- [x] OCR now extracts 2631 chars from scanned PDF (was 4 chars before)
- [ ] CI tests pass

Closes #16