### PR TITLE
ci: use self-hosted arc-happyvertical runners

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   check:
     name: Check for Changeset
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
 
     steps:
       - name: Checkout

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   validate-commits:
     name: Validate Conventional Commits
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
 
     steps:
       - name: Checkout PR branch

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
   release:
     name: Version and Publish
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     timeout-minutes: 20
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   test:
     name: Run Tests
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

Migrate all GitHub Actions workflows from `ubuntu-latest` to the organization's self-hosted `arc-happyvertical` runners for improved performance and cost efficiency.

## Changes

- Update `runs-on` in all workflow files to use `arc-happyvertical`

## Testing

- Workflow files updated and validated

Closes #N/A - Organization-wide CI improvement initiative