### PR TITLE
fix(ci): handle multi-line commit bodies in auto-changeset

### DIFF
--- a/scripts/auto-changeset.ts
+++ b/scripts/auto-changeset.ts
@@ -48,12 +48,13 @@ function getCommitsSinceLastRelease(): string[] {
   }
 
   const commits = exec(
-    `git log ${range} --pretty=format:"%H|||%s|||%b" --no-merges`,
+    `git log ${range} --pretty=format:"%H|||%s|||%b%x00" --no-merges`,
   );
 
   if (!commits) return [];
 
-  return commits.split('\n').filter(Boolean);
+  // Split on null byte (not newline) to handle multi-line commit bodies
+  return commits.split('\x00').map((s) => s.trim()).filter(Boolean);
 }
 
 function parseConventionalCommit(commitLine: string): ParsedCommit | null {


### PR DESCRIPTION
## Summary
- Fix auto-changeset script failing to parse commits with multi-line bodies
- Use null byte (`%x00`) as record separator instead of splitting on newlines