### PR TITLE
fix(pdf): harden large document batching

### DIFF
--- a/.changeset/large-pdf-batching.md
+++ b/.changeset/large-pdf-batching.md
@@ -1,0 +1,5 @@
+---
+'@happyvertical/pdf': patch
+---
+
+Add transparent batched extraction for large PDFs, propagate configured `maxFileSize` through providers, and fail explicitly on incomplete batch extraction instead of returning partial success.

--- a/package.json
+++ b/package.json
@@ -15,11 +15,7 @@
       "pdfjs-dist": "5.4.296"
     }
   },
-  "files": [
-    "dist",
-    "README.md",
-    "LICENSE"
-  ],
+  "files": ["dist", "README.md", "LICENSE"],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com",
     "access": "public"

--- a/src/browser/factory.ts
+++ b/src/browser/factory.ts
@@ -13,7 +13,7 @@ import type { PDFReader, PDFReaderOptions } from '../shared/types';
 export async function getPDFReader(
   options: PDFReaderOptions = {},
 ): Promise<PDFReader> {
-  const { provider = 'auto', ...readerOptions } = options;
+  const { provider = 'auto' } = options;
 
   // In browser, we only support PDF.js-based providers
   let selectedProvider = provider;
@@ -62,7 +62,13 @@ export function isProviderAvailable(provider: string): boolean {
  */
 export async function getProviderInfo(provider: string) {
   try {
-    const reader = await getPDFReader({ provider: provider as any });
+    if (provider !== 'auto' && provider !== 'pdfjs') {
+      throw new Error(
+        `PDF provider '${provider}' is not available in browser environments. Available providers: pdfjs`,
+      );
+    }
+
+    const reader = await getPDFReader({ provider });
     const [capabilities, dependencies] = await Promise.all([
       reader.checkCapabilities(),
       reader.checkDependencies(),

--- a/src/browser/pdfjs.ts
+++ b/src/browser/pdfjs.ts
@@ -2,6 +2,7 @@
  * @happyvertical/pdf - PDF.js provider for browser PDF processing
  */
 
+import type { TextItem } from 'pdfjs-dist/types/src/display/api';
 import { BasePDFReader } from '../shared/base';
 import type {
   DependencyCheckResult,
@@ -13,6 +14,34 @@ import type {
 } from '../shared/types';
 import { PDFDependencyError, PDFUnsupportedError } from '../shared/types';
 
+type PDFJSModule = typeof import('pdfjs-dist/legacy/build/pdf.mjs');
+type BrowserPDFJSGlobal = typeof globalThis & {
+  window?: {
+    pdfjsLib?: PDFJSModule;
+  };
+};
+type PDFMetadataInfo = Record<string, unknown>;
+
+function readTextItem(item: TextItem | { type: string; id: string }): string {
+  return 'str' in item ? item.str : '';
+}
+
+function getMetadataInfoValue(
+  info: object | null | undefined,
+  key: string,
+): string | undefined {
+  const value = (info as PDFMetadataInfo | null | undefined)?.[key];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function getMetadataInfoDate(
+  info: object | null | undefined,
+  key: string,
+): Date | undefined {
+  const value = getMetadataInfoValue(info, key);
+  return value ? new Date(value) : undefined;
+}
+
 /**
  * PDF reader implementation using PDF.js for browser environments
  *
@@ -23,7 +52,7 @@ import { PDFDependencyError, PDFUnsupportedError } from '../shared/types';
  */
 export class PDFJSProvider extends BasePDFReader {
   protected name = 'pdfjs';
-  private pdfjs: any = null;
+  private pdfjs: PDFJSModule | null = null;
 
   // The browser base class already provides normalizeSource, so we don't need to override it
 
@@ -36,14 +65,12 @@ export class PDFJSProvider extends BasePDFReader {
     }
 
     try {
+      const browserGlobal = globalThis as BrowserPDFJSGlobal;
+
       // Try to load PDF.js from CDN or local installation
       // This is a placeholder - actual implementation would depend on how PDF.js is loaded
-      if (
-        typeof globalThis !== 'undefined' &&
-        (globalThis as any).window &&
-        (globalThis as any).window.pdfjsLib
-      ) {
-        this.pdfjs = (globalThis as any).window.pdfjsLib;
+      if (browserGlobal.window?.pdfjsLib) {
+        this.pdfjs = browserGlobal.window.pdfjsLib;
       } else {
         throw new Error(
           'PDF.js library not found. Please include PDF.js in your project.',
@@ -91,10 +118,7 @@ export class PDFJSProvider extends BasePDFReader {
           const textContent = await page.getTextContent();
 
           // Combine text items into a single string
-          const pageText = textContent.items
-            .map((item: any) => item.str || '')
-            .join(' ')
-            .trim();
+          const pageText = textContent.items.map(readTextItem).join(' ').trim();
 
           pageTexts.push(pageText);
         } catch (pageError) {
@@ -132,20 +156,16 @@ export class PDFJSProvider extends BasePDFReader {
 
       return {
         pageCount: pdf.numPages,
-        title: metadata?.info?.Title || undefined,
-        author: metadata?.info?.Author || undefined,
-        subject: metadata?.info?.Subject || undefined,
-        keywords: metadata?.info?.Keywords || undefined,
-        creationDate: metadata?.info?.CreationDate
-          ? new Date(metadata.info.CreationDate)
-          : undefined,
-        modificationDate: metadata?.info?.ModDate
-          ? new Date(metadata.info.ModDate)
-          : undefined,
-        version: metadata?.info?.PDFFormatVersion || undefined,
-        creator: metadata?.info?.Creator || undefined,
-        producer: metadata?.info?.Producer || undefined,
-        encrypted: metadata?.info?.Encrypted === 'Yes',
+        title: getMetadataInfoValue(metadata?.info, 'Title'),
+        author: getMetadataInfoValue(metadata?.info, 'Author'),
+        subject: getMetadataInfoValue(metadata?.info, 'Subject'),
+        keywords: getMetadataInfoValue(metadata?.info, 'Keywords'),
+        creationDate: getMetadataInfoDate(metadata?.info, 'CreationDate'),
+        modificationDate: getMetadataInfoDate(metadata?.info, 'ModDate'),
+        version: getMetadataInfoValue(metadata?.info, 'PDFFormatVersion'),
+        creator: getMetadataInfoValue(metadata?.info, 'Creator'),
+        producer: getMetadataInfoValue(metadata?.info, 'Producer'),
+        encrypted: getMetadataInfoValue(metadata?.info, 'Encrypted') === 'Yes',
       };
     } catch (error) {
       console.error('PDF.js metadata extraction failed:', error);
@@ -181,7 +201,7 @@ export class PDFJSProvider extends BasePDFReader {
       for (let pageNum = 1; pageNum <= pdf.numPages; pageNum++) {
         try {
           const page = await pdf.getPage(pageNum);
-          const _operators = await page.getOperatorList();
+          await page.getOperatorList();
 
           // This is a simplified implementation - PDF.js doesn't have
           // a direct equivalent to unpdf's extractImages function

--- a/src/factory.test.ts
+++ b/src/factory.test.ts
@@ -1,10 +1,11 @@
-import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   getAvailableProviders,
   getPDFReader,
   getProviderInfo,
   isProviderAvailable,
 } from './index';
+import { KreuzbergProvider } from './node/kreuzberg';
 
 describe('PDF Factory Tests', () => {
   it('should create a PDF reader with auto provider selection', async () => {
@@ -89,6 +90,45 @@ describe('PDF Factory Tests', () => {
       maxFileSize: 50 * 1024 * 1024, // 50MB
     });
     expect(reader).toBeDefined();
+  });
+
+  it('should propagate configured maxFileSize to reader capabilities', async () => {
+    const reader = await getPDFReader({
+      provider: 'unpdf',
+      maxFileSize: 64 * 1024 * 1024,
+    });
+
+    await expect(reader.checkCapabilities()).resolves.toMatchObject({
+      maxFileSize: 64 * 1024 * 1024,
+    });
+  });
+
+  it('should throw configured maxFileSize errors from Kreuzberg extraction', async () => {
+    const reader = new KreuzbergProvider({
+      maxFileSize: 4,
+    });
+
+    await expect(reader.extractText(Buffer.from('12345678'))).rejects.toThrow(
+      'PDF exceeds configured maxFileSize',
+    );
+  });
+
+  it('should normalize in-memory sources only once during Kreuzberg extraction', async () => {
+    const reader = new KreuzbergProvider({
+      ocrBackend: 'mock',
+    }) as any;
+
+    const normalized = Buffer.from('pdf-data');
+
+    reader.normalizeSource = vi.fn().mockResolvedValue(normalized);
+    reader.loadKreuzberg = vi.fn().mockResolvedValue({
+      extractBytes: vi.fn().mockResolvedValue({ content: 'ok' }),
+    });
+
+    await expect(
+      reader.extractText(new Uint8Array([1, 2, 3, 4])),
+    ).resolves.toBe('ok');
+    expect(reader.normalizeSource).toHaveBeenCalledTimes(1);
   });
 
   describe('Environment Variable Configuration', () => {

--- a/src/factory.test.ts
+++ b/src/factory.test.ts
@@ -50,6 +50,12 @@ describe('PDF Factory Tests', () => {
     );
   });
 
+  it('should reject unknown provider values instead of silently falling back', async () => {
+    await expect(getPDFReader({ provider: 'unpfd' as any })).rejects.toThrow(
+      'Unknown PDF provider: unpfd',
+    );
+  });
+
   it('should return available providers for Node.js environment', () => {
     const providers = getAvailableProviders();
     expect(Array.isArray(providers)).toBe(true);
@@ -126,7 +132,7 @@ describe('PDF Factory Tests', () => {
     });
 
     await expect(
-      reader.extractText(new Uint8Array([1, 2, 3, 4])),
+      reader.extractText(new Uint8Array([1, 2, 3, 4]).buffer),
     ).resolves.toBe('ok');
     expect(reader.normalizeSource).toHaveBeenCalledTimes(1);
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ export * from './shared/types';
 
 // Legacy compatibility exports for backward compatibility with existing code
 import { getPDFReader, initializeProviders } from './shared/factory';
+import type { PDFImage } from './shared/types';
 
 /**
  * Extract text from a PDF file (legacy compatibility)
@@ -39,7 +40,7 @@ export async function extractTextFromPDF(
 export async function extractImagesFromPDF(
   pdfPath: string,
   options?: { provider?: 'unpdf' | 'kreuzberg' | 'auto' },
-): Promise<any[] | null> {
+): Promise<PDFImage[] | null> {
   const reader = await getPDFReader({ provider: options?.provider ?? 'unpdf' });
   const images = await reader.extractImages(pdfPath);
   return images.length > 0 ? images : null;
@@ -51,7 +52,7 @@ export async function extractImagesFromPDF(
  * @note Requires unpdf provider - kreuzberg integrates OCR into extractText()
  */
 export async function performOCROnImages(
-  images: any[],
+  images: PDFImage[],
   options?: { provider?: 'unpdf' | 'kreuzberg' | 'auto' },
 ): Promise<string> {
   const reader = await getPDFReader({ provider: options?.provider ?? 'unpdf' });

--- a/src/node/combined.test.ts
+++ b/src/node/combined.test.ts
@@ -32,6 +32,303 @@ describe('CombinedNodeProvider', () => {
       },
     });
   });
+
+  it('batches large text-based PDFs and preserves batch order when pages are merged', async () => {
+    const reader = new CombinedNodeProvider() as any;
+
+    reader.getInfo = vi.fn().mockResolvedValue({
+      pageCount: 60,
+      fileSize: 40 * 1024 * 1024,
+      encrypted: false,
+      hasEmbeddedText: true,
+      hasImages: false,
+      recommendedStrategy: 'text',
+      ocrRequired: false,
+      estimatedProcessingTime: {
+        textExtraction: 'slow',
+      },
+    });
+
+    reader.unpdfProvider = {
+      extractText: vi.fn().mockImplementation(async (_source, options) => {
+        const pages = options?.pages ?? [];
+        return `[${pages[0]}-${pages[pages.length - 1]}]`;
+      }),
+    };
+
+    const text = await reader.extractText('/tmp/large.pdf', {
+      mergePages: true,
+    });
+
+    expect(text).toBe('[1-25] [26-50] [51-60]');
+    expect(reader.unpdfProvider.extractText).toHaveBeenCalledTimes(3);
+    expect(reader.unpdfProvider.extractText).toHaveBeenNthCalledWith(
+      1,
+      '/tmp/large.pdf',
+      expect.objectContaining({
+        pages: Array.from({ length: 25 }, (_, index) => index + 1),
+        mergePages: true,
+        skipOCRFallback: true,
+      }),
+    );
+  });
+
+  it('preserves per-page boundaries for large text PDFs when mergePages is false', async () => {
+    const reader = new CombinedNodeProvider() as any;
+
+    reader.getInfo = vi.fn().mockResolvedValue({
+      pageCount: 4,
+      fileSize: 40 * 1024 * 1024,
+      encrypted: false,
+      hasEmbeddedText: true,
+      hasImages: false,
+      recommendedStrategy: 'text',
+      ocrRequired: false,
+      estimatedProcessingTime: {
+        textExtraction: 'slow',
+      },
+    });
+
+    reader.unpdfProvider = {
+      extractText: vi.fn().mockImplementation(async (_source, options) => {
+        const page = options?.pages?.[0];
+        return `page-${page}`;
+      }),
+    };
+
+    const text = await reader.extractText('/tmp/large.pdf', {
+      mergePages: false,
+    });
+
+    expect(text).toBe('page-1\n\npage-2\n\npage-3\n\npage-4');
+    expect(reader.unpdfProvider.extractText).toHaveBeenCalledTimes(4);
+    expect(reader.unpdfProvider.extractText).toHaveBeenNthCalledWith(
+      1,
+      '/tmp/large.pdf',
+      expect.objectContaining({
+        pages: [1],
+        mergePages: true,
+        skipOCRFallback: true,
+      }),
+    );
+  });
+
+  it('batches OCR extraction for large image-based PDFs', async () => {
+    const reader = new CombinedNodeProvider() as any;
+
+    reader.getInfo = vi.fn().mockResolvedValue({
+      pageCount: 9,
+      fileSize: 30 * 1024 * 1024,
+      encrypted: false,
+      hasEmbeddedText: false,
+      hasImages: true,
+      recommendedStrategy: 'ocr',
+      ocrRequired: true,
+      estimatedProcessingTime: {
+        textExtraction: 'slow',
+        ocrProcessing: 'slow',
+      },
+    });
+
+    reader.unpdfProvider = {
+      renderPages: vi.fn().mockImplementation(async (_source, options) => {
+        return (options?.pages ?? []).map((pageNumber: number) => ({
+          data: Buffer.from([pageNumber]),
+          format: 'rgb',
+          width: 10,
+          height: 10,
+          channels: 3,
+          pageNumber,
+        }));
+      }),
+    };
+    reader.ocrFactory = {
+      performOCR: vi
+        .fn()
+        .mockImplementation(async (images: Array<{ pageNumber?: number }>) => ({
+          text: `ocr:${images.map((image) => image.pageNumber).join(',')}`,
+          confidence: 99,
+        })),
+    };
+
+    const text = await reader.extractText('/tmp/scanned.pdf', {
+      mergePages: true,
+    });
+
+    expect(text).toBe('ocr:1,2,3,4 ocr:5,6,7,8 ocr:9');
+    expect(reader.unpdfProvider.renderPages).toHaveBeenCalledTimes(3);
+    expect(reader.ocrFactory.performOCR).toHaveBeenCalledTimes(3);
+  });
+
+  it('respects skipOCRFallback for large OCR-recommended PDFs', async () => {
+    const reader = new CombinedNodeProvider() as any;
+
+    reader.getInfo = vi.fn().mockResolvedValue({
+      pageCount: 8,
+      fileSize: 32 * 1024 * 1024,
+      encrypted: false,
+      hasEmbeddedText: false,
+      hasImages: true,
+      recommendedStrategy: 'ocr',
+      ocrRequired: true,
+      estimatedProcessingTime: {
+        textExtraction: 'slow',
+        ocrProcessing: 'slow',
+      },
+    });
+
+    reader.unpdfProvider = {
+      extractText: vi.fn().mockImplementation(async (_source, options) => {
+        const pages = options?.pages ?? [];
+        return `direct:${pages[0]}-${pages[pages.length - 1]}`;
+      }),
+    };
+    reader.ocrFactory = {
+      performOCR: vi.fn(),
+    };
+
+    const text = await reader.extractText('/tmp/scanned.pdf', {
+      mergePages: true,
+      skipOCRFallback: true,
+    });
+
+    expect(text).toBe('direct:1-8');
+    expect(reader.ocrFactory.performOCR).not.toHaveBeenCalled();
+    expect(reader.unpdfProvider.extractText).toHaveBeenCalledOnce();
+  });
+
+  it('falls back to OCR for sparse hybrid batches', async () => {
+    const reader = new CombinedNodeProvider() as any;
+
+    reader.getInfo = vi.fn().mockResolvedValue({
+      pageCount: 8,
+      fileSize: 32 * 1024 * 1024,
+      encrypted: false,
+      hasEmbeddedText: true,
+      hasImages: true,
+      recommendedStrategy: 'hybrid',
+      ocrRequired: false,
+      estimatedProcessingTime: {
+        textExtraction: 'slow',
+        ocrProcessing: 'slow',
+      },
+    });
+
+    reader.unpdfProvider = {
+      extractText: vi.fn().mockImplementation(async (_source, options) => {
+        const firstPage = options?.pages?.[0];
+        return firstPage === 1
+          ? 'brief'
+          : 'This batch already has enough direct text to avoid OCR fallback. '.repeat(
+              5,
+            );
+      }),
+      renderPages: vi.fn().mockImplementation(async (_source, options) => {
+        return (options?.pages ?? []).map((pageNumber: number) => ({
+          data: Buffer.from([pageNumber]),
+          format: 'rgb',
+          width: 10,
+          height: 10,
+          channels: 3,
+          pageNumber,
+        }));
+      }),
+    };
+    reader.ocrFactory = {
+      performOCR: vi.fn().mockResolvedValue({
+        text: 'ocr rescued batch',
+        confidence: 98,
+      }),
+    };
+
+    const text = await reader.extractText('/tmp/hybrid.pdf', {
+      mergePages: true,
+    });
+
+    expect(text).toBe(
+      `ocr rescued batch ${'This batch already has enough direct text to avoid OCR fallback. '.repeat(5).trim()}`,
+    );
+    expect(reader.ocrFactory.performOCR).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws on mid-batch failures instead of returning partial text', async () => {
+    const reader = new CombinedNodeProvider() as any;
+
+    reader.getInfo = vi.fn().mockResolvedValue({
+      pageCount: 60,
+      fileSize: 40 * 1024 * 1024,
+      encrypted: false,
+      hasEmbeddedText: true,
+      hasImages: false,
+      recommendedStrategy: 'text',
+      ocrRequired: false,
+      estimatedProcessingTime: {
+        textExtraction: 'slow',
+      },
+    });
+
+    reader.unpdfProvider = {
+      extractText: vi
+        .fn()
+        .mockResolvedValueOnce('first batch')
+        .mockRejectedValueOnce(new Error('page parse failed')),
+    };
+
+    await expect(reader.extractText('/tmp/broken.pdf')).rejects.toThrow(
+      'Large PDF extraction failed for pages 26-50: page parse failed',
+    );
+  });
+
+  it('reports configured maxFileSize through capabilities', async () => {
+    const reader = new CombinedNodeProvider({
+      maxFileSize: 64 * 1024 * 1024,
+    }) as any;
+
+    reader.unpdfProvider = {
+      checkCapabilities: vi.fn().mockResolvedValue({
+        canExtractText: true,
+        canExtractMetadata: true,
+        canExtractImages: true,
+        canPerformOCR: false,
+        supportedFormats: ['pdf'],
+        maxFileSize: undefined,
+      }),
+    };
+    reader.ocrFactory = {
+      isOCRAvailable: vi.fn().mockResolvedValue(true),
+      getSupportedLanguages: vi.fn().mockResolvedValue(['eng']),
+    };
+
+    await expect(reader.checkCapabilities()).resolves.toMatchObject({
+      maxFileSize: 64 * 1024 * 1024,
+      ocrLanguages: ['eng'],
+    });
+  });
+
+  it('reports the lower provider maxFileSize when it is stricter than the configured ceiling', async () => {
+    const reader = new CombinedNodeProvider({
+      maxFileSize: 64 * 1024 * 1024,
+    }) as any;
+
+    reader.unpdfProvider = {
+      checkCapabilities: vi.fn().mockResolvedValue({
+        canExtractText: true,
+        canExtractMetadata: true,
+        canExtractImages: true,
+        canPerformOCR: false,
+        supportedFormats: ['pdf'],
+        maxFileSize: 16 * 1024 * 1024,
+      }),
+    };
+    reader.ocrFactory = {
+      isOCRAvailable: vi.fn().mockResolvedValue(false),
+      getSupportedLanguages: vi.fn(),
+    };
+
+    await expect(reader.checkCapabilities()).resolves.toMatchObject({
+      maxFileSize: 16 * 1024 * 1024,
+    });
+  });
 });
 
 describe('UnpdfProvider', () => {

--- a/src/node/combined.test.ts
+++ b/src/node/combined.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { PDFBatchExtractionError, PDFFileSizeError } from '../shared/types';
 import { CombinedNodeProvider } from './combined';
 import { UnpdfProvider } from './unpdf';
 
@@ -35,6 +36,7 @@ describe('CombinedNodeProvider', () => {
 
   it('batches large text-based PDFs and preserves batch order when pages are merged', async () => {
     const reader = new CombinedNodeProvider() as any;
+    reader.getSourceByteLength = vi.fn().mockResolvedValue(40 * 1024 * 1024);
 
     reader.getInfo = vi.fn().mockResolvedValue({
       pageCount: 60,
@@ -75,6 +77,7 @@ describe('CombinedNodeProvider', () => {
 
   it('preserves per-page boundaries for large text PDFs when mergePages is false', async () => {
     const reader = new CombinedNodeProvider() as any;
+    reader.getSourceByteLength = vi.fn().mockResolvedValue(40 * 1024 * 1024);
 
     reader.getInfo = vi.fn().mockResolvedValue({
       pageCount: 4,
@@ -113,8 +116,39 @@ describe('CombinedNodeProvider', () => {
     );
   });
 
+  it('preserves per-page boundaries by default for large text PDFs', async () => {
+    const reader = new CombinedNodeProvider() as any;
+    reader.getSourceByteLength = vi.fn().mockResolvedValue(40 * 1024 * 1024);
+
+    reader.getInfo = vi.fn().mockResolvedValue({
+      pageCount: 3,
+      fileSize: 40 * 1024 * 1024,
+      encrypted: false,
+      hasEmbeddedText: true,
+      hasImages: false,
+      recommendedStrategy: 'text',
+      ocrRequired: false,
+      estimatedProcessingTime: {
+        textExtraction: 'slow',
+      },
+    });
+
+    reader.unpdfProvider = {
+      extractText: vi.fn().mockImplementation(async (_source, options) => {
+        const page = options?.pages?.[0];
+        return `page-${page}`;
+      }),
+    };
+
+    const text = await reader.extractText('/tmp/large.pdf');
+
+    expect(text).toBe('page-1\n\npage-2\n\npage-3');
+    expect(reader.unpdfProvider.extractText).toHaveBeenCalledTimes(3);
+  });
+
   it('batches OCR extraction for large image-based PDFs', async () => {
     const reader = new CombinedNodeProvider() as any;
+    reader.getSourceByteLength = vi.fn().mockResolvedValue(30 * 1024 * 1024);
 
     reader.getInfo = vi.fn().mockResolvedValue({
       pageCount: 9,
@@ -162,6 +196,7 @@ describe('CombinedNodeProvider', () => {
 
   it('respects skipOCRFallback for large OCR-recommended PDFs', async () => {
     const reader = new CombinedNodeProvider() as any;
+    reader.getSourceByteLength = vi.fn().mockResolvedValue(32 * 1024 * 1024);
 
     reader.getInfo = vi.fn().mockResolvedValue({
       pageCount: 8,
@@ -199,6 +234,7 @@ describe('CombinedNodeProvider', () => {
 
   it('falls back to OCR for sparse hybrid batches', async () => {
     const reader = new CombinedNodeProvider() as any;
+    reader.getSourceByteLength = vi.fn().mockResolvedValue(32 * 1024 * 1024);
 
     reader.getInfo = vi.fn().mockResolvedValue({
       pageCount: 8,
@@ -253,6 +289,7 @@ describe('CombinedNodeProvider', () => {
 
   it('throws on mid-batch failures instead of returning partial text', async () => {
     const reader = new CombinedNodeProvider() as any;
+    reader.getSourceByteLength = vi.fn().mockResolvedValue(40 * 1024 * 1024);
 
     reader.getInfo = vi.fn().mockResolvedValue({
       pageCount: 60,
@@ -274,9 +311,50 @@ describe('CombinedNodeProvider', () => {
         .mockRejectedValueOnce(new Error('page parse failed')),
     };
 
-    await expect(reader.extractText('/tmp/broken.pdf')).rejects.toThrow(
+    const extractionPromise = reader.extractText('/tmp/broken.pdf', {
+      mergePages: true,
+    });
+
+    await expect(extractionPromise).rejects.toBeInstanceOf(
+      PDFBatchExtractionError,
+    );
+    await expect(extractionPromise).rejects.toThrow(
       'Large PDF extraction failed for pages 26-50: page parse failed',
     );
+  });
+
+  it('throws configured maxFileSize before analyzing oversized inputs', async () => {
+    const reader = new CombinedNodeProvider({ maxFileSize: 4 }) as any;
+    reader.getInfo = vi.fn();
+
+    await expect(
+      reader.extractText(new Uint8Array([1, 2, 3, 4, 5])),
+    ).rejects.toBeInstanceOf(PDFFileSizeError);
+    expect(reader.getInfo).not.toHaveBeenCalled();
+  });
+
+  it('skips expensive getInfo for small inputs without paging hints', async () => {
+    const reader = new CombinedNodeProvider() as any;
+    reader.getInfo = vi.fn();
+    reader.unpdfProvider = {
+      extractText: vi.fn().mockResolvedValue('direct text'),
+    };
+
+    await expect(
+      reader.extractText(new Uint8Array([1, 2, 3, 4])),
+    ).resolves.toBe('direct text');
+    expect(reader.getInfo).not.toHaveBeenCalled();
+  });
+
+  it('accepts ArrayBuffer sources in the direct extraction path', async () => {
+    const reader = new CombinedNodeProvider() as any;
+    reader.unpdfProvider = {
+      extractText: vi.fn().mockResolvedValue('array-buffer-text'),
+    };
+
+    await expect(
+      reader.extractText(new Uint8Array([1, 2, 3, 4]).buffer),
+    ).resolves.toBe('array-buffer-text');
   });
 
   it('reports configured maxFileSize through capabilities', async () => {

--- a/src/node/combined.ts
+++ b/src/node/combined.ts
@@ -2,6 +2,7 @@
  * @happyvertical/pdf - Combined Node.js PDF reader with unpdf + OCR capabilities
  */
 
+import { stat } from 'node:fs/promises';
 import { getOCR } from '@happyvertical/ocr';
 import { BasePDFReader } from '../shared/base';
 import type {
@@ -17,6 +18,12 @@ import type {
 } from '../shared/types';
 import { UnpdfProvider } from './unpdf';
 
+const LARGE_DOCUMENT_BATCH_BYTES = 20 * 1024 * 1024;
+const TEXT_BATCH_SIZE = 25;
+const OCR_BATCH_SIZE = 4;
+const HYBRID_BATCH_SIZE = 4;
+const HYBRID_DIRECT_TEXT_MIN_CHARS_PER_PAGE = 50;
+
 /**
  * Combined PDF reader for Node.js that integrates unpdf and OCR capabilities
  *
@@ -29,11 +36,260 @@ export class CombinedNodeProvider extends BasePDFReader {
   protected name = 'combined-node';
   private unpdfProvider: UnpdfProvider;
   private ocrFactory: ReturnType<typeof getOCR>;
+  private maxFileSize?: number;
 
-  constructor(options: { ocrProvider?: string } = {}) {
+  constructor(options: { ocrProvider?: string; maxFileSize?: number } = {}) {
     super();
     this.unpdfProvider = new UnpdfProvider();
     this.ocrFactory = getOCR({ provider: options.ocrProvider || 'auto' });
+    this.maxFileSize = options.maxFileSize;
+  }
+
+  private isInvalidSource(source: PDFSource): boolean {
+    return (
+      !source ||
+      (typeof source === 'string' && source.trim() === '') ||
+      (typeof source === 'object' &&
+        Object.keys(source).length === 0 &&
+        !(source instanceof Buffer) &&
+        !(source instanceof Uint8Array))
+    );
+  }
+
+  private async getSourceByteLength(
+    source: PDFSource,
+  ): Promise<number | undefined> {
+    if (typeof source === 'string') {
+      try {
+        const info = await stat(source);
+        return info.size;
+      } catch {
+        return undefined;
+      }
+    }
+
+    if (source instanceof Uint8Array) {
+      return source.byteLength;
+    }
+
+    if (source instanceof ArrayBuffer) {
+      return source.byteLength;
+    }
+
+    return undefined;
+  }
+
+  private async assertWithinConfiguredMaxFileSize(
+    source: PDFSource,
+    reportedFileSize?: number,
+  ): Promise<void> {
+    if (!this.maxFileSize) {
+      return;
+    }
+
+    const fileSize =
+      reportedFileSize ?? (await this.getSourceByteLength(source));
+    if (!fileSize || fileSize <= this.maxFileSize) {
+      return;
+    }
+
+    const actualMB = (fileSize / 1024 / 1024).toFixed(1);
+    const limitMB = (this.maxFileSize / 1024 / 1024).toFixed(1);
+    throw new Error(
+      `PDF exceeds configured maxFileSize (${actualMB}MB > ${limitMB}MB)`,
+    );
+  }
+
+  private chunkPages(pages: number[], batchSize: number): number[][] {
+    const batches: number[][] = [];
+
+    for (let index = 0; index < pages.length; index += batchSize) {
+      batches.push(pages.slice(index, index + batchSize));
+    }
+
+    return batches;
+  }
+
+  private shouldUseBatchedProcessing(
+    info: PDFInfo,
+    pagesToExtract: number[],
+    options?: ExtractTextOptions,
+  ): boolean {
+    if (options?.pages && pagesToExtract.length <= 1) {
+      return false;
+    }
+
+    if (pagesToExtract.length <= 1) {
+      return false;
+    }
+
+    const fileSize = info.fileSize ?? 0;
+    if (fileSize >= LARGE_DOCUMENT_BATCH_BYTES) {
+      return true;
+    }
+
+    if (
+      info.recommendedStrategy === 'ocr' ||
+      info.recommendedStrategy === 'hybrid'
+    ) {
+      return pagesToExtract.length > OCR_BATCH_SIZE;
+    }
+
+    return pagesToExtract.length > TEXT_BATCH_SIZE;
+  }
+
+  private getBatchSizeForStrategy(
+    strategy: PDFInfo['recommendedStrategy'],
+  ): number {
+    if (strategy === 'ocr') {
+      return OCR_BATCH_SIZE;
+    }
+
+    if (strategy === 'hybrid') {
+      return HYBRID_BATCH_SIZE;
+    }
+
+    return TEXT_BATCH_SIZE;
+  }
+
+  private async extractTextPageWise(
+    source: PDFSource,
+    pages: number[],
+    strategy: PDFInfo['recommendedStrategy'],
+    options?: ExtractTextOptions,
+  ): Promise<string[]> {
+    const pageTexts: string[] = [];
+
+    for (const page of pages) {
+      if (strategy === 'ocr') {
+        pageTexts.push(await this.extractOcrBatch(source, [page]));
+      } else if (strategy === 'hybrid') {
+        pageTexts.push(await this.extractHybridBatch(source, [page], options));
+      } else {
+        pageTexts.push(await this.extractTextBatch(source, [page], options));
+      }
+    }
+
+    return pageTexts;
+  }
+
+  private async extractTextBatch(
+    source: PDFSource,
+    pages: number[],
+    options?: ExtractTextOptions,
+  ): Promise<string> {
+    return (
+      (await this.unpdfProvider.extractText(source, {
+        ...options,
+        pages,
+        mergePages: true,
+        skipOCRFallback: true,
+      })) ?? ''
+    ).trim();
+  }
+
+  private async extractOcrBatch(
+    source: PDFSource,
+    pages: number[],
+  ): Promise<string> {
+    const renderedPages = await this.unpdfProvider.renderPages(source, {
+      scale: 2.0,
+      pages,
+    });
+
+    if (!renderedPages.length) {
+      return '';
+    }
+
+    const ocrResult = await this.ocrFactory.performOCR(renderedPages);
+    return ocrResult.text?.trim() || '';
+  }
+
+  private async extractHybridBatch(
+    source: PDFSource,
+    pages: number[],
+    options?: ExtractTextOptions,
+  ): Promise<string> {
+    const directText = await this.extractTextBatch(source, pages, options);
+    const directTextLooksComplete =
+      directText.length >= pages.length * HYBRID_DIRECT_TEXT_MIN_CHARS_PER_PAGE;
+
+    if (directTextLooksComplete) {
+      return directText;
+    }
+
+    try {
+      const ocrText = await this.extractOcrBatch(source, pages);
+      if (!ocrText) {
+        return directText;
+      }
+
+      if (!directText) {
+        return ocrText;
+      }
+
+      return ocrText.length > directText.length * 1.2 ? ocrText : directText;
+    } catch (error) {
+      if (directText) {
+        return directText;
+      }
+
+      throw error;
+    }
+  }
+
+  private async extractTextBatched(
+    source: PDFSource,
+    info: PDFInfo,
+    pagesToExtract: number[],
+    options?: ExtractTextOptions,
+  ): Promise<string | null> {
+    const strategy = options?.skipOCRFallback
+      ? 'text'
+      : info.recommendedStrategy;
+
+    if (options?.mergePages === false) {
+      const pageTexts = await this.extractTextPageWise(
+        source,
+        pagesToExtract,
+        strategy,
+        options,
+      );
+      const mergedText = this.mergePageTexts(pageTexts, false);
+      return mergedText.trim() ? mergedText : null;
+    }
+
+    const batchTexts: string[] = [];
+    const batches = this.chunkPages(
+      pagesToExtract,
+      this.getBatchSizeForStrategy(strategy),
+    );
+
+    for (const pages of batches) {
+      const batchLabel = `${pages[0]}-${pages[pages.length - 1]}`;
+
+      try {
+        let batchText = '';
+
+        if (strategy === 'ocr') {
+          batchText = await this.extractOcrBatch(source, pages);
+        } else if (strategy === 'hybrid') {
+          batchText = await this.extractHybridBatch(source, pages, options);
+        } else {
+          batchText = await this.extractTextBatch(source, pages, options);
+        }
+
+        batchTexts.push(batchText);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(
+          `Large PDF extraction failed for pages ${batchLabel}: ${message}`,
+        );
+      }
+    }
+
+    const mergedText = this.mergePageTexts(batchTexts, options?.mergePages);
+    return mergedText.trim() ? mergedText : null;
   }
 
   /**
@@ -43,7 +299,28 @@ export class CombinedNodeProvider extends BasePDFReader {
     source: PDFSource,
     options?: ExtractTextOptions,
   ): Promise<string | null> {
+    if (this.isInvalidSource(source)) {
+      return null;
+    }
+
     try {
+      const info = await this.getInfo(source);
+      await this.assertWithinConfiguredMaxFileSize(source, info.fileSize);
+
+      if (info.pageCount > 0) {
+        const pagesToExtract = this.normalizePages(
+          options?.pages,
+          info.pageCount,
+        );
+
+        if (
+          pagesToExtract.length > 0 &&
+          this.shouldUseBatchedProcessing(info, pagesToExtract, options)
+        ) {
+          return this.extractTextBatched(source, info, pagesToExtract, options);
+        }
+      }
+
       // First try direct text extraction using unpdf
       const text = await this.unpdfProvider.extractText(source, options);
 
@@ -70,6 +347,14 @@ export class CombinedNodeProvider extends BasePDFReader {
 
       return text;
     } catch (error) {
+      if (
+        error instanceof Error &&
+        (error.message.includes('Large PDF extraction failed') ||
+          error.message.includes('configured maxFileSize'))
+      ) {
+        throw error;
+      }
+
       console.error('Combined text extraction failed:', error);
       return null;
     }
@@ -124,13 +409,18 @@ export class CombinedNodeProvider extends BasePDFReader {
       ocrLanguages = await this.ocrFactory.getSupportedLanguages();
     }
 
+    const maxFileSize =
+      this.maxFileSize && unpdfCaps.maxFileSize
+        ? Math.min(this.maxFileSize, unpdfCaps.maxFileSize)
+        : (this.maxFileSize ?? unpdfCaps.maxFileSize);
+
     return {
       canExtractText: unpdfCaps.canExtractText || ocrAvailable, // Can extract text directly or via OCR
       canExtractMetadata: unpdfCaps.canExtractMetadata,
       canExtractImages: unpdfCaps.canExtractImages,
       canPerformOCR: ocrAvailable,
       supportedFormats: unpdfCaps.supportedFormats,
-      maxFileSize: unpdfCaps.maxFileSize,
+      maxFileSize,
       ocrLanguages: ocrLanguages.length > 0 ? ocrLanguages : undefined,
     };
   }

--- a/src/node/combined.ts
+++ b/src/node/combined.ts
@@ -16,6 +16,7 @@ import type {
   PDFMetadata,
   PDFSource,
 } from '../shared/types';
+import { PDFBatchExtractionError, PDFFileSizeError } from '../shared/types';
 import { UnpdfProvider } from './unpdf';
 
 const LARGE_DOCUMENT_BATCH_BYTES = 20 * 1024 * 1024;
@@ -23,6 +24,8 @@ const TEXT_BATCH_SIZE = 25;
 const OCR_BATCH_SIZE = 4;
 const HYBRID_BATCH_SIZE = 4;
 const HYBRID_DIRECT_TEXT_MIN_CHARS_PER_PAGE = 50;
+const HYBRID_OCR_CONFIDENCE_THRESHOLD = 85;
+const HYBRID_OCR_LENGTH_ADVANTAGE_RATIO = 1.2;
 
 /**
  * Combined PDF reader for Node.js that integrates unpdf and OCR capabilities
@@ -46,14 +49,19 @@ export class CombinedNodeProvider extends BasePDFReader {
   }
 
   private isInvalidSource(source: PDFSource): boolean {
-    return (
-      !source ||
-      (typeof source === 'string' && source.trim() === '') ||
-      (typeof source === 'object' &&
-        Object.keys(source).length === 0 &&
-        !(source instanceof Buffer) &&
-        !(source instanceof Uint8Array))
-    );
+    if (!source) {
+      return true;
+    }
+
+    if (typeof source === 'string') {
+      return source.trim() === '';
+    }
+
+    if (source instanceof Uint8Array || source instanceof ArrayBuffer) {
+      return source.byteLength === 0;
+    }
+
+    return false;
   }
 
   private async getSourceByteLength(
@@ -93,11 +101,18 @@ export class CombinedNodeProvider extends BasePDFReader {
       return;
     }
 
-    const actualMB = (fileSize / 1024 / 1024).toFixed(1);
-    const limitMB = (this.maxFileSize / 1024 / 1024).toFixed(1);
-    throw new Error(
-      `PDF exceeds configured maxFileSize (${actualMB}MB > ${limitMB}MB)`,
-    );
+    throw new PDFFileSizeError(fileSize, this.maxFileSize);
+  }
+
+  private shouldInspectForBatching(
+    sourceByteLength: number | undefined,
+    options?: ExtractTextOptions,
+  ): boolean {
+    if (sourceByteLength && sourceByteLength >= LARGE_DOCUMENT_BATCH_BYTES) {
+      return true;
+    }
+
+    return Boolean(options?.pages && options.pages.length > OCR_BATCH_SIZE);
   }
 
   private chunkPages(pages: number[], batchSize: number): number[][] {
@@ -113,12 +128,7 @@ export class CombinedNodeProvider extends BasePDFReader {
   private shouldUseBatchedProcessing(
     info: PDFInfo,
     pagesToExtract: number[],
-    options?: ExtractTextOptions,
   ): boolean {
-    if (options?.pages && pagesToExtract.length <= 1) {
-      return false;
-    }
-
     if (pagesToExtract.length <= 1) {
       return false;
     }
@@ -161,12 +171,19 @@ export class CombinedNodeProvider extends BasePDFReader {
     const pageTexts: string[] = [];
 
     for (const page of pages) {
-      if (strategy === 'ocr') {
-        pageTexts.push(await this.extractOcrBatch(source, [page]));
-      } else if (strategy === 'hybrid') {
-        pageTexts.push(await this.extractHybridBatch(source, [page], options));
-      } else {
-        pageTexts.push(await this.extractTextBatch(source, [page], options));
+      try {
+        if (strategy === 'ocr') {
+          pageTexts.push(await this.extractOcrBatchText(source, [page]));
+        } else if (strategy === 'hybrid') {
+          pageTexts.push(
+            await this.extractHybridBatch(source, [page], options),
+          );
+        } else {
+          pageTexts.push(await this.extractTextBatch(source, [page], options));
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new PDFBatchExtractionError([page], message);
       }
     }
 
@@ -191,17 +208,27 @@ export class CombinedNodeProvider extends BasePDFReader {
   private async extractOcrBatch(
     source: PDFSource,
     pages: number[],
-  ): Promise<string> {
+  ): Promise<OCRResult> {
     const renderedPages = await this.unpdfProvider.renderPages(source, {
       scale: 2.0,
       pages,
     });
 
     if (!renderedPages.length) {
-      return '';
+      return {
+        text: '',
+        confidence: 0,
+      };
     }
 
-    const ocrResult = await this.ocrFactory.performOCR(renderedPages);
+    return this.ocrFactory.performOCR(renderedPages);
+  }
+
+  private async extractOcrBatchText(
+    source: PDFSource,
+    pages: number[],
+  ): Promise<string> {
+    const ocrResult = await this.extractOcrBatch(source, pages);
     return ocrResult.text?.trim() || '';
   }
 
@@ -219,7 +246,9 @@ export class CombinedNodeProvider extends BasePDFReader {
     }
 
     try {
-      const ocrText = await this.extractOcrBatch(source, pages);
+      const ocrResult = await this.extractOcrBatch(source, pages);
+      const ocrText = ocrResult.text?.trim() || '';
+
       if (!ocrText) {
         return directText;
       }
@@ -228,7 +257,13 @@ export class CombinedNodeProvider extends BasePDFReader {
         return ocrText;
       }
 
-      return ocrText.length > directText.length * 1.2 ? ocrText : directText;
+      // Only prefer OCR when it is materially richer than the embedded text
+      // and the OCR engine is reporting a meaningfully strong confidence score.
+      const confidence = ocrResult.confidence ?? 0;
+      return confidence >= HYBRID_OCR_CONFIDENCE_THRESHOLD &&
+        ocrText.length > directText.length * HYBRID_OCR_LENGTH_ADVANTAGE_RATIO
+        ? ocrText
+        : directText;
     } catch (error) {
       if (directText) {
         return directText;
@@ -248,7 +283,7 @@ export class CombinedNodeProvider extends BasePDFReader {
       ? 'text'
       : info.recommendedStrategy;
 
-    if (options?.mergePages === false) {
+    if (options?.mergePages !== true) {
       const pageTexts = await this.extractTextPageWise(
         source,
         pagesToExtract,
@@ -266,13 +301,11 @@ export class CombinedNodeProvider extends BasePDFReader {
     );
 
     for (const pages of batches) {
-      const batchLabel = `${pages[0]}-${pages[pages.length - 1]}`;
-
       try {
         let batchText = '';
 
         if (strategy === 'ocr') {
-          batchText = await this.extractOcrBatch(source, pages);
+          batchText = await this.extractOcrBatchText(source, pages);
         } else if (strategy === 'hybrid') {
           batchText = await this.extractHybridBatch(source, pages, options);
         } else {
@@ -282,9 +315,7 @@ export class CombinedNodeProvider extends BasePDFReader {
         batchTexts.push(batchText);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        throw new Error(
-          `Large PDF extraction failed for pages ${batchLabel}: ${message}`,
-        );
+        throw new PDFBatchExtractionError(pages, message);
       }
     }
 
@@ -304,20 +335,29 @@ export class CombinedNodeProvider extends BasePDFReader {
     }
 
     try {
-      const info = await this.getInfo(source);
-      await this.assertWithinConfiguredMaxFileSize(source, info.fileSize);
+      const sourceByteLength = await this.getSourceByteLength(source);
+      await this.assertWithinConfiguredMaxFileSize(source, sourceByteLength);
 
-      if (info.pageCount > 0) {
-        const pagesToExtract = this.normalizePages(
-          options?.pages,
-          info.pageCount,
-        );
+      if (this.shouldInspectForBatching(sourceByteLength, options)) {
+        const info = await this.getInfo(source);
 
-        if (
-          pagesToExtract.length > 0 &&
-          this.shouldUseBatchedProcessing(info, pagesToExtract, options)
-        ) {
-          return this.extractTextBatched(source, info, pagesToExtract, options);
+        if (info.pageCount > 0) {
+          const pagesToExtract = this.normalizePages(
+            options?.pages,
+            info.pageCount,
+          );
+
+          if (
+            pagesToExtract.length > 0 &&
+            this.shouldUseBatchedProcessing(info, pagesToExtract)
+          ) {
+            return this.extractTextBatched(
+              source,
+              info,
+              pagesToExtract,
+              options,
+            );
+          }
         }
       }
 
@@ -348,9 +388,8 @@ export class CombinedNodeProvider extends BasePDFReader {
       return text;
     } catch (error) {
       if (
-        error instanceof Error &&
-        (error.message.includes('Large PDF extraction failed') ||
-          error.message.includes('configured maxFileSize'))
+        error instanceof PDFBatchExtractionError ||
+        error instanceof PDFFileSizeError
       ) {
         throw error;
       }

--- a/src/node/kreuzberg.ts
+++ b/src/node/kreuzberg.ts
@@ -6,7 +6,6 @@
  */
 
 import { promises as fs } from 'node:fs';
-import type { ExtractionConfig, ExtractionResult } from '@kreuzberg/node';
 import { BasePDFReader } from '../shared/base';
 import type {
   DependencyCheckResult,
@@ -19,25 +18,38 @@ import type {
   PDFMetadata,
   PDFSource,
 } from '../shared/types';
-import { PDFDependencyError, PDFUnsupportedError } from '../shared/types';
+import {
+  PDFDependencyError,
+  PDFFileSizeError,
+  PDFUnsupportedError,
+} from '../shared/types';
 import { ensureTessdataPrefix, formatPdfOcrRuntimeIssue } from './ocr-runtime';
 
-type KreuzbergModule = typeof import('@kreuzberg/node');
-type KreuzbergPdfMetadata = {
-  pageCount?: number;
-  page_count?: number;
-  title?: string;
-  author?: string;
-  subject?: string;
-  keywords?: string;
-  creationDate?: string;
-  modificationDate?: string;
-  pdfVersion?: string;
-  version?: string;
-  creator?: string;
-  producer?: string;
-  encrypted?: boolean;
-  isEncrypted?: boolean;
+type KreuzbergExtractionConfig = {
+  ocr?: {
+    backend: string;
+    language?: string;
+    tesseractConfig?: {
+      enableTableDetection?: boolean;
+    };
+  };
+};
+type KreuzbergResult = {
+  content?: string | null;
+  metadata?: Record<string, unknown>;
+};
+type KreuzbergModule = {
+  extractFile(
+    filePath: string,
+    mimeType?: string | null,
+    config?: KreuzbergExtractionConfig | null,
+  ): Promise<KreuzbergResult>;
+  extractBytes(
+    data: Buffer,
+    mimeType: string,
+    config?: KreuzbergExtractionConfig | null,
+  ): Promise<KreuzbergResult>;
+  listOcrBackends?: () => string[];
 };
 
 /**
@@ -118,9 +130,11 @@ export class KreuzbergProvider extends BasePDFReader {
       return source;
     } else if (source instanceof Uint8Array) {
       return Buffer.from(source);
+    } else if (source instanceof ArrayBuffer) {
+      return Buffer.from(source);
     } else {
       throw new Error(
-        'Invalid PDF source: must be file path, Buffer, or Uint8Array',
+        'Invalid PDF source: must be file path, Buffer, ArrayBuffer, or Uint8Array',
       );
     }
   }
@@ -129,11 +143,11 @@ export class KreuzbergProvider extends BasePDFReader {
    * Build Kreuzberg extraction config from options
    */
   private buildConfig(options?: ExtractTextOptions) {
-    const config: ExtractionConfig = {};
+    const config: KreuzbergExtractionConfig = {};
 
     // Configure OCR if not explicitly skipped
     if (!options?.skipOCRFallback) {
-      const ocrConfig: NonNullable<ExtractionConfig['ocr']> = {
+      const ocrConfig: NonNullable<KreuzbergExtractionConfig['ocr']> = {
         backend: this.options.ocrBackend || 'tesseract',
         language: this.options.ocrLanguage,
       };
@@ -171,10 +185,10 @@ export class KreuzbergProvider extends BasePDFReader {
     if (
       !source ||
       (typeof source === 'string' && source.trim() === '') ||
-      (typeof source === 'object' &&
-        Object.keys(source).length === 0 &&
-        !(source instanceof Buffer) &&
-        !(source instanceof Uint8Array))
+      ((source instanceof Buffer ||
+        source instanceof Uint8Array ||
+        source instanceof ArrayBuffer) &&
+        source.byteLength === 0)
     ) {
       return null;
     }
@@ -192,18 +206,14 @@ export class KreuzbergProvider extends BasePDFReader {
       }
 
       if (this.options.maxFileSize && sourceSize > this.options.maxFileSize) {
-        const actualMB = (sourceSize / 1024 / 1024).toFixed(1);
-        const limitMB = (this.options.maxFileSize / 1024 / 1024).toFixed(1);
-        throw new Error(
-          `PDF exceeds configured maxFileSize (${actualMB}MB > ${limitMB}MB)`,
-        );
+        throw new PDFFileSizeError(sourceSize, this.options.maxFileSize);
       }
 
       tessdata = await this.prepareOCRRuntime(options);
       const kreuzberg = await this.loadKreuzberg();
       const config = this.buildConfig(options);
 
-      let result: ExtractionResult | null = null;
+      let result: KreuzbergResult | null = null;
 
       if (typeof source === 'string') {
         // File path - use extractFile for best performance
@@ -224,10 +234,7 @@ export class KreuzbergProvider extends BasePDFReader {
 
       return result.content;
     } catch (error) {
-      if (
-        error instanceof Error &&
-        error.message.includes('configured maxFileSize')
-      ) {
+      if (error instanceof PDFFileSizeError) {
         throw error;
       }
 
@@ -248,7 +255,7 @@ export class KreuzbergProvider extends BasePDFReader {
     try {
       const kreuzberg = await this.loadKreuzberg();
 
-      let result: ExtractionResult | null = null;
+      let result: KreuzbergResult | null = null;
 
       if (typeof source === 'string') {
         result = await kreuzberg.extractFile(source, null, null);
@@ -258,24 +265,51 @@ export class KreuzbergProvider extends BasePDFReader {
       }
 
       // Kreuzberg returns metadata in the result object
-      const metadata = (result?.metadata || {}) as KreuzbergPdfMetadata;
+      const metadata = result?.metadata || {};
+      const readString = (...keys: string[]): string | undefined => {
+        for (const key of keys) {
+          const value = metadata[key];
+          if (typeof value === 'string') {
+            return value;
+          }
+        }
+        return undefined;
+      };
+      const readNumber = (...keys: string[]): number | undefined => {
+        for (const key of keys) {
+          const value = metadata[key];
+          if (typeof value === 'number') {
+            return value;
+          }
+        }
+        return undefined;
+      };
+      const readBoolean = (...keys: string[]): boolean | undefined => {
+        for (const key of keys) {
+          const value = metadata[key];
+          if (typeof value === 'boolean') {
+            return value;
+          }
+        }
+        return undefined;
+      };
+      const creationDate = readString('creationDate');
+      const modificationDate = readString('modificationDate');
 
       return {
-        pageCount: metadata.pageCount || metadata.page_count || 0,
-        title: metadata.title || undefined,
-        author: metadata.author || undefined,
-        subject: metadata.subject || undefined,
-        keywords: metadata.keywords || undefined,
-        creationDate: metadata.creationDate
-          ? new Date(metadata.creationDate)
+        pageCount: readNumber('pageCount', 'page_count') ?? 0,
+        title: readString('title'),
+        author: readString('author'),
+        subject: readString('subject'),
+        keywords: readString('keywords'),
+        creationDate: creationDate ? new Date(creationDate) : undefined,
+        modificationDate: modificationDate
+          ? new Date(modificationDate)
           : undefined,
-        modificationDate: metadata.modificationDate
-          ? new Date(metadata.modificationDate)
-          : undefined,
-        version: metadata.pdfVersion || metadata.version || undefined,
-        creator: metadata.creator || undefined,
-        producer: metadata.producer || undefined,
-        encrypted: metadata.encrypted ?? metadata.isEncrypted ?? false,
+        version: readString('pdfVersion', 'version'),
+        creator: readString('creator'),
+        producer: readString('producer'),
+        encrypted: readBoolean('encrypted', 'isEncrypted') ?? false,
       };
     } catch (error) {
       console.error('Kreuzberg metadata extraction failed:', error);

--- a/src/node/kreuzberg.ts
+++ b/src/node/kreuzberg.ts
@@ -6,6 +6,7 @@
  */
 
 import { promises as fs } from 'node:fs';
+import type { ExtractionConfig, ExtractionResult } from '@kreuzberg/node';
 import { BasePDFReader } from '../shared/base';
 import type {
   DependencyCheckResult,
@@ -21,6 +22,24 @@ import type {
 import { PDFDependencyError, PDFUnsupportedError } from '../shared/types';
 import { ensureTessdataPrefix, formatPdfOcrRuntimeIssue } from './ocr-runtime';
 
+type KreuzbergModule = typeof import('@kreuzberg/node');
+type KreuzbergPdfMetadata = {
+  pageCount?: number;
+  page_count?: number;
+  title?: string;
+  author?: string;
+  subject?: string;
+  keywords?: string;
+  creationDate?: string;
+  modificationDate?: string;
+  pdfVersion?: string;
+  version?: string;
+  creator?: string;
+  producer?: string;
+  encrypted?: boolean;
+  isEncrypted?: boolean;
+};
+
 /**
  * Configuration options for the Kreuzberg provider
  */
@@ -31,6 +50,8 @@ export interface KreuzbergProviderOptions {
   ocrLanguage?: string;
   /** Enable table detection during OCR */
   enableTableDetection?: boolean;
+  /** Optional configured max file size ceiling */
+  maxFileSize?: number;
 }
 
 /**
@@ -50,7 +71,7 @@ export interface KreuzbergProviderOptions {
  */
 export class KreuzbergProvider extends BasePDFReader {
   protected name = 'kreuzberg';
-  private kreuzberg: any = null;
+  private kreuzberg: KreuzbergModule | null = null;
   private options: KreuzbergProviderOptions;
 
   constructor(options: KreuzbergProviderOptions = {}) {
@@ -59,6 +80,7 @@ export class KreuzbergProvider extends BasePDFReader {
       ocrBackend: options.ocrBackend || 'tesseract',
       ocrLanguage: options.ocrLanguage || 'eng',
       enableTableDetection: options.enableTableDetection ?? true,
+      maxFileSize: options.maxFileSize,
     };
   }
 
@@ -107,17 +129,18 @@ export class KreuzbergProvider extends BasePDFReader {
    * Build Kreuzberg extraction config from options
    */
   private buildConfig(options?: ExtractTextOptions) {
-    const config: any = {};
+    const config: ExtractionConfig = {};
 
     // Configure OCR if not explicitly skipped
     if (!options?.skipOCRFallback) {
-      config.ocr = {
-        backend: this.options.ocrBackend,
+      const ocrConfig: NonNullable<ExtractionConfig['ocr']> = {
+        backend: this.options.ocrBackend || 'tesseract',
         language: this.options.ocrLanguage,
       };
+      config.ocr = ocrConfig;
 
       if (this.options.enableTableDetection) {
-        config.ocr.tesseractConfig = {
+        ocrConfig.tesseractConfig = {
           enableTableDetection: true,
         };
       }
@@ -157,20 +180,37 @@ export class KreuzbergProvider extends BasePDFReader {
     }
 
     let tessdata = null;
+    let normalizedBuffer: Buffer | null = null;
 
     try {
+      let sourceSize: number;
+      if (typeof source === 'string') {
+        sourceSize = (await fs.stat(source)).size;
+      } else {
+        normalizedBuffer = await this.normalizeSource(source);
+        sourceSize = normalizedBuffer.byteLength;
+      }
+
+      if (this.options.maxFileSize && sourceSize > this.options.maxFileSize) {
+        const actualMB = (sourceSize / 1024 / 1024).toFixed(1);
+        const limitMB = (this.options.maxFileSize / 1024 / 1024).toFixed(1);
+        throw new Error(
+          `PDF exceeds configured maxFileSize (${actualMB}MB > ${limitMB}MB)`,
+        );
+      }
+
       tessdata = await this.prepareOCRRuntime(options);
       const kreuzberg = await this.loadKreuzberg();
       const config = this.buildConfig(options);
 
-      let result;
+      let result: ExtractionResult | null = null;
 
       if (typeof source === 'string') {
         // File path - use extractFile for best performance
         result = await kreuzberg.extractFile(source, null, config);
       } else {
         // Buffer/Uint8Array - use extractBytes
-        const buffer = await this.normalizeSource(source);
+        const buffer = normalizedBuffer ?? (await this.normalizeSource(source));
         result = await kreuzberg.extractBytes(
           buffer,
           'application/pdf',
@@ -184,6 +224,13 @@ export class KreuzbergProvider extends BasePDFReader {
 
       return result.content;
     } catch (error) {
+      if (
+        error instanceof Error &&
+        error.message.includes('configured maxFileSize')
+      ) {
+        throw error;
+      }
+
       const message = formatPdfOcrRuntimeIssue(error, {
         backend: this.options.ocrBackend,
         language: this.options.ocrLanguage,
@@ -201,7 +248,7 @@ export class KreuzbergProvider extends BasePDFReader {
     try {
       const kreuzberg = await this.loadKreuzberg();
 
-      let result;
+      let result: ExtractionResult | null = null;
 
       if (typeof source === 'string') {
         result = await kreuzberg.extractFile(source, null, null);
@@ -211,7 +258,7 @@ export class KreuzbergProvider extends BasePDFReader {
       }
 
       // Kreuzberg returns metadata in the result object
-      const metadata = result?.metadata || {};
+      const metadata = (result?.metadata || {}) as KreuzbergPdfMetadata;
 
       return {
         pageCount: metadata.pageCount || metadata.page_count || 0,
@@ -228,7 +275,7 @@ export class KreuzbergProvider extends BasePDFReader {
         version: metadata.pdfVersion || metadata.version || undefined,
         creator: metadata.creator || undefined,
         producer: metadata.producer || undefined,
-        encrypted: metadata.encrypted || false,
+        encrypted: metadata.encrypted ?? metadata.isEncrypted ?? false,
       };
     } catch (error) {
       console.error('Kreuzberg metadata extraction failed:', error);
@@ -313,7 +360,7 @@ export class KreuzbergProvider extends BasePDFReader {
         'tiff',
         'webp',
       ],
-      maxFileSize: undefined, // Kreuzberg handles streaming for large files
+      maxFileSize: this.options.maxFileSize,
       ocrLanguages: [
         'eng',
         'deu',

--- a/src/node/unpdf.ts
+++ b/src/node/unpdf.ts
@@ -6,6 +6,15 @@ import { promises as fs } from 'node:fs';
 import { createRequire } from 'node:module';
 import { pathToFileURL } from 'node:url';
 import { Canvas } from '@napi-rs/canvas';
+import type {
+  CanvasRenderingContext2D as NapiCanvasRenderingContext2D,
+  SKRSContext2D,
+} from '@napi-rs/canvas';
+import type {
+  PDFPageProxy,
+  RenderParameters,
+  TextItem,
+} from 'pdfjs-dist/types/src/display/api';
 import { BasePDFReader } from '../shared/base';
 import type {
   DependencyCheckResult,
@@ -22,6 +31,43 @@ import { formatPdfOcrRuntimeIssue } from './ocr-runtime';
 
 const require = createRequire(import.meta.url);
 
+type UnpdfModule = typeof import('unpdf');
+type TextMarkedContent = { type: string; id: string };
+type NodeRenderableContext = NapiCanvasRenderingContext2D | SKRSContext2D;
+type PDFMetadataInfo = Record<string, unknown>;
+
+function readTextItem(item: TextItem | TextMarkedContent): string {
+  return 'str' in item ? item.str : '';
+}
+
+function createNodeRenderParameters(
+  page: PDFPageProxy,
+  canvasContext: NodeRenderableContext,
+  scale: number,
+): RenderParameters {
+  return {
+    canvas: null,
+    canvasContext: canvasContext as unknown as CanvasRenderingContext2D,
+    viewport: page.getViewport({ scale }),
+  };
+}
+
+function getMetadataInfoValue(
+  info: object | null | undefined,
+  key: string,
+): string | undefined {
+  const value = (info as PDFMetadataInfo | null | undefined)?.[key];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function getMetadataInfoDate(
+  info: object | null | undefined,
+  key: string,
+): Date | undefined {
+  const value = getMetadataInfoValue(info, key);
+  return value ? new Date(value) : undefined;
+}
+
 /**
  * PDF reader implementation using unpdf library for Node.js
  *
@@ -32,7 +78,7 @@ const require = createRequire(import.meta.url);
  */
 export class UnpdfProvider extends BasePDFReader {
   protected name = 'unpdf';
-  private unpdf: any = null;
+  private unpdf: UnpdfModule | null = null;
   private configuredPdfjsWorkerSrc: string | null = null;
 
   private rgbaToRgbBuffer(data: Uint8ClampedArray): Buffer {
@@ -172,10 +218,7 @@ export class UnpdfProvider extends BasePDFReader {
           const textContent = await page.getTextContent();
 
           // Combine text items into a single string
-          const pageText = textContent.items
-            .map((item: any) => item.str || '')
-            .join(' ')
-            .trim();
+          const pageText = textContent.items.map(readTextItem).join(' ').trim();
 
           pageTexts.push(pageText);
         } catch (pageError) {
@@ -214,20 +257,16 @@ export class UnpdfProvider extends BasePDFReader {
 
       return {
         pageCount: pdf.numPages,
-        title: metadata?.info?.Title || undefined,
-        author: metadata?.info?.Author || undefined,
-        subject: metadata?.info?.Subject || undefined,
-        keywords: metadata?.info?.Keywords || undefined,
-        creationDate: metadata?.info?.CreationDate
-          ? new Date(metadata.info.CreationDate)
-          : undefined,
-        modificationDate: metadata?.info?.ModDate
-          ? new Date(metadata.info.ModDate)
-          : undefined,
-        version: metadata?.info?.PDFFormatVersion || undefined,
-        creator: metadata?.info?.Creator || undefined,
-        producer: metadata?.info?.Producer || undefined,
-        encrypted: metadata?.info?.Encrypted === 'Yes',
+        title: getMetadataInfoValue(metadata?.info, 'Title'),
+        author: getMetadataInfoValue(metadata?.info, 'Author'),
+        subject: getMetadataInfoValue(metadata?.info, 'Subject'),
+        keywords: getMetadataInfoValue(metadata?.info, 'Keywords'),
+        creationDate: getMetadataInfoDate(metadata?.info, 'CreationDate'),
+        modificationDate: getMetadataInfoDate(metadata?.info, 'ModDate'),
+        version: getMetadataInfoValue(metadata?.info, 'PDFFormatVersion'),
+        creator: getMetadataInfoValue(metadata?.info, 'Creator'),
+        producer: getMetadataInfoValue(metadata?.info, 'Producer'),
+        encrypted: getMetadataInfoValue(metadata?.info, 'Encrypted') === 'Yes',
       };
     } catch (error) {
       console.error('unpdf metadata extraction failed:', error);
@@ -290,14 +329,14 @@ export class UnpdfProvider extends BasePDFReader {
 
           // Convert unpdf image format to our PDFImage format with BMP conversion
           for (const image of images) {
-            const rawData =
+            const rawData: Buffer =
               image.data instanceof Buffer
                 ? image.data
                 : Buffer.from(image.data);
 
             // Direct RGB data processing - optimal path for OCR
-            let processedData = rawData;
-            let format = image.format || 'unknown';
+            let processedData: Buffer = rawData;
+            let format = 'unknown';
 
             // If we have raw RGB data (3 channels), keep it as raw RGB
             if (image.channels === 3 && image.width && image.height) {
@@ -380,18 +419,16 @@ export class UnpdfProvider extends BasePDFReader {
 
         for (const pageNumber of pagesToRender) {
           const page = await document.getPage(pageNumber);
-          const viewport = page.getViewport({ scale: options?.scale || 2.0 });
+          const scale = options?.scale || 2.0;
+          const viewport = page.getViewport({ scale });
           const width = Math.ceil(viewport.width);
           const height = Math.ceil(viewport.height);
           const canvas = new Canvas(width, height);
           const context = canvas.getContext('2d');
 
           try {
-            await page.render({
-              canvas: canvas as any,
-              canvasContext: context as any,
-              viewport,
-            }).promise;
+            await page.render(createNodeRenderParameters(page, context, scale))
+              .promise;
 
             const imageData = context.getImageData(0, 0, width, height);
 
@@ -509,9 +546,8 @@ export class UnpdfProvider extends BasePDFReader {
             hasEmbeddedText = true;
             // Estimate text length based on sample
             const pageTextLength = content.items.reduce(
-              (len: number, item: any) => {
-                return len + (item.str ? item.str.length : 0);
-              },
+              (len: number, item: TextItem | TextMarkedContent) =>
+                len + readTextItem(item).length,
               0,
             );
             estimatedTextLength += pageTextLength;
@@ -576,8 +612,8 @@ export class UnpdfProvider extends BasePDFReader {
       return {
         pageCount,
         fileSize: buffer.length,
-        version: metadata?.info?.PDFFormatVersion || undefined,
-        encrypted: metadata?.info?.Encrypted === 'Yes',
+        version: getMetadataInfoValue(metadata?.info, 'PDFFormatVersion'),
+        encrypted: getMetadataInfoValue(metadata?.info, 'Encrypted') === 'Yes',
         hasEmbeddedText,
         hasImages,
         estimatedTextLength:
@@ -585,13 +621,11 @@ export class UnpdfProvider extends BasePDFReader {
         recommendedStrategy,
         ocrRequired,
         estimatedProcessingTime,
-        title: metadata?.info?.Title || undefined,
-        author: metadata?.info?.Author || undefined,
-        creationDate: metadata?.info?.CreationDate
-          ? new Date(metadata.info.CreationDate)
-          : undefined,
-        creator: metadata?.info?.Creator || undefined,
-        producer: metadata?.info?.Producer || undefined,
+        title: getMetadataInfoValue(metadata?.info, 'Title'),
+        author: getMetadataInfoValue(metadata?.info, 'Author'),
+        creationDate: getMetadataInfoDate(metadata?.info, 'CreationDate'),
+        creator: getMetadataInfoValue(metadata?.info, 'Creator'),
+        producer: getMetadataInfoValue(metadata?.info, 'Producer'),
       };
     } catch (error) {
       console.error('unpdf getInfo failed:', error);

--- a/src/shared/factory.ts
+++ b/src/shared/factory.ts
@@ -5,6 +5,8 @@
 import { loadEnvConfig } from '@happyvertical/utils';
 import type { PDFReader, PDFReaderOptions } from './types';
 
+type RuntimeProvider = NonNullable<PDFReaderOptions['provider']>;
+
 /**
  * Check if the kreuzberg provider is available (optional dependency)
  */
@@ -20,6 +22,31 @@ async function isKreuzbergAvailable(): Promise<boolean> {
 function requiresExternalOCRProvider(ocrProvider?: string): boolean {
   return Boolean(
     ocrProvider && ocrProvider !== 'auto' && ocrProvider !== 'tesseract',
+  );
+}
+
+function isBrowserRuntime(): boolean {
+  if (typeof globalThis === 'undefined') {
+    return false;
+  }
+
+  const browserGlobal = globalThis as typeof globalThis & {
+    window?: unknown;
+    document?: unknown;
+  };
+
+  return (
+    typeof browserGlobal.window !== 'undefined' &&
+    typeof browserGlobal.document !== 'undefined'
+  );
+}
+
+function isRuntimeProvider(value: string): value is RuntimeProvider {
+  return (
+    value === 'auto' ||
+    value === 'unpdf' ||
+    value === 'pdfjs' ||
+    value === 'kreuzberg'
   );
 }
 
@@ -116,18 +143,15 @@ export async function getPDFReader(
     },
   });
 
-  const provider = (config.provider ?? 'auto') as NonNullable<
-    PDFReaderOptions['provider']
-  >;
+  const provider = isRuntimeProvider(config.provider ?? 'auto')
+    ? (config.provider ?? 'auto')
+    : 'auto';
   const readerOptions: PDFReaderOptions = { ...config, provider };
 
   // Environment detection for automatic provider selection
   const isNode =
     typeof process !== 'undefined' && process?.versions?.node !== undefined;
-  const isBrowser =
-    typeof globalThis !== 'undefined' &&
-    typeof (globalThis as any).window !== 'undefined' &&
-    typeof (globalThis as any).document !== 'undefined';
+  const isBrowser = isBrowserRuntime();
 
   // Select provider based on environment and preference
   let selectedProvider = provider;
@@ -163,6 +187,7 @@ export async function getPDFReader(
       const { CombinedNodeProvider } = await import('../node/combined.js');
       return new CombinedNodeProvider({
         ocrProvider: readerOptions.ocrProvider as string | undefined,
+        maxFileSize: readerOptions.maxFileSize,
       });
     }
 
@@ -184,6 +209,7 @@ export async function getPDFReader(
       return new KreuzbergProvider({
         ocrBackend: readerOptions.ocrProvider as string | undefined,
         ocrLanguage: options.defaultOCROptions?.language,
+        maxFileSize: readerOptions.maxFileSize,
       });
     }
 
@@ -238,10 +264,7 @@ export function getAvailableProviders(): string[] {
 
   const isNode =
     typeof process !== 'undefined' && process?.versions?.node !== undefined;
-  const isBrowser =
-    typeof globalThis !== 'undefined' &&
-    typeof (globalThis as any).window !== 'undefined' &&
-    typeof (globalThis as any).document !== 'undefined';
+  const isBrowser = isBrowserRuntime();
 
   if (isNode) {
     // Both kreuzberg and unpdf are available in Node.js
@@ -324,7 +347,11 @@ export function isProviderAvailable(provider: string): boolean {
  */
 export async function getProviderInfo(provider: string) {
   try {
-    const reader = await getPDFReader({ provider: provider as any });
+    if (!isRuntimeProvider(provider)) {
+      throw new Error(`Unknown PDF provider: ${provider}`);
+    }
+
+    const reader = await getPDFReader({ provider });
     const [capabilities, dependencies] = await Promise.all([
       reader.checkCapabilities(),
       reader.checkDependencies(),

--- a/src/shared/factory.ts
+++ b/src/shared/factory.ts
@@ -143,9 +143,12 @@ export async function getPDFReader(
     },
   });
 
-  const provider = isRuntimeProvider(config.provider ?? 'auto')
-    ? (config.provider ?? 'auto')
-    : 'auto';
+  const requestedProvider = config.provider ?? 'auto';
+  if (!isRuntimeProvider(requestedProvider)) {
+    throw new Error(`Unknown PDF provider: ${requestedProvider}`);
+  }
+
+  const provider = requestedProvider;
   const readerOptions: PDFReaderOptions = { ...config, provider };
 
   // Environment detection for automatic provider selection

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -543,6 +543,36 @@ export class PDFDependencyError extends PDFError {
   }
 }
 
+export class PDFFileSizeError extends PDFError {
+  constructor(
+    public actualSizeBytes: number,
+    public maxSizeBytes: number,
+  ) {
+    const actualMB = (actualSizeBytes / 1024 / 1024).toFixed(1);
+    const limitMB = (maxSizeBytes / 1024 / 1024).toFixed(1);
+    super(`PDF exceeds configured maxFileSize (${actualMB}MB > ${limitMB}MB)`);
+    this.code = 'EMAXFILE';
+    this.name = 'PDFFileSizeError';
+  }
+}
+
+export class PDFBatchExtractionError extends PDFError {
+  constructor(
+    public pages: number[],
+    details?: string,
+  ) {
+    const batchLabel =
+      pages.length > 1
+        ? `${pages[0]}-${pages[pages.length - 1]}`
+        : `${pages[0]}`;
+    super(
+      `Large PDF extraction failed for pages ${batchLabel}${details ? `: ${details}` : ''}`,
+    );
+    this.code = 'EBATCH';
+    this.name = 'PDFBatchExtractionError';
+  }
+}
+
 /**
  * Lightweight PDF document analysis providing processing strategy recommendations
  *


### PR DESCRIPTION
## Summary
- preserve page boundaries and skip-OCR behavior in large-document batching
- enforce configured file-size ceilings consistently across combined and Kreuzberg readers
- add regressions for batching order, capability reporting, and Kreuzberg in-memory handling

## Verification
- pnpm typecheck
- pnpm test