### PR TITLE
fix(pdf): keep auto reader modular in node

### DIFF
--- a/.changeset/auto-image-provider.md
+++ b/.changeset/auto-image-provider.md
@@ -1,0 +1,6 @@
+---
+'@happyvertical/pdf': patch
+---
+
+Keep Node `provider: "auto"` on the combined reader so modular operations like
+`extractImages()` stay available alongside text extraction and OCR.

--- a/package.json
+++ b/package.json
@@ -15,11 +15,7 @@
       "pdfjs-dist": "5.4.296"
     }
   },
-  "files": [
-    "dist",
-    "README.md",
-    "LICENSE"
-  ],
+  "files": ["dist", "README.md", "LICENSE"],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com",
     "access": "public"

--- a/src/extraction.test.ts
+++ b/src/extraction.test.ts
@@ -53,6 +53,17 @@ describe('PDF Content Extraction', () => {
     }
   });
 
+  it('should keep image extraction working with the auto reader', async () => {
+    const images = await reader.extractImages(pdfPath);
+
+    expect(images.length).toBe(3);
+    for (const image of images) {
+      expect(image.data).toBeDefined();
+      expect(image.width).toBeGreaterThan(0);
+      expect(image.height).toBeGreaterThan(0);
+    }
+  });
+
   it('should extract text from scanned PDF via OCR fallback', async () => {
     const text = await reader.extractText(pdfPath);
 

--- a/src/factory.test.ts
+++ b/src/factory.test.ts
@@ -11,6 +11,7 @@ describe('PDF Factory Tests', () => {
   it('should create a PDF reader with auto provider selection', async () => {
     const reader = await getPDFReader();
     expect(reader).toBeDefined();
+    expect(reader.constructor.name).toBe('CombinedNodeProvider');
     expect(typeof reader.extractText).toBe('function');
     expect(typeof reader.extractMetadata).toBe('function');
     expect(typeof reader.extractImages).toBe('function');
@@ -23,6 +24,14 @@ describe('PDF Factory Tests', () => {
     const reader = await getPDFReader({ provider: 'unpdf' });
     expect(reader).toBeDefined();
     expect(reader.constructor.name).toBe('CombinedNodeProvider');
+  });
+
+  it('should keep extractImages available when using auto provider selection', async () => {
+    const reader = await getPDFReader({ provider: 'auto' });
+    const capabilities = await reader.checkCapabilities();
+
+    expect(reader.constructor.name).toBe('CombinedNodeProvider');
+    expect(capabilities.canExtractImages).toBe(true);
   });
 
   it('should route explicit onnx OCR requests to unpdf provider', async () => {

--- a/src/factory.test.ts
+++ b/src/factory.test.ts
@@ -5,6 +5,7 @@ import {
   getProviderInfo,
   isProviderAvailable,
 } from './index';
+import { CombinedNodeProvider } from './node/combined';
 import { KreuzbergProvider } from './node/kreuzberg';
 
 describe('PDF Factory Tests', () => {
@@ -32,6 +33,55 @@ describe('PDF Factory Tests', () => {
 
     expect(reader.constructor.name).toBe('CombinedNodeProvider');
     expect(capabilities.canExtractImages).toBe(true);
+  });
+
+  it('should preserve default OCR options when using auto provider selection', async () => {
+    const reader = (await getPDFReader({
+      provider: 'auto',
+      defaultOCROptions: {
+        language: 'fra',
+        confidenceThreshold: 70,
+      },
+    })) as any;
+
+    expect(reader.constructor.name).toBe('CombinedNodeProvider');
+    expect(reader.defaultOCROptions).toMatchObject({
+      language: 'fra',
+      confidenceThreshold: 70,
+    });
+  });
+
+  it('should fall back to Kreuzberg when combined reader dependencies are unavailable', async () => {
+    const combinedDepsSpy = vi
+      .spyOn(CombinedNodeProvider.prototype, 'checkDependencies')
+      .mockResolvedValueOnce({
+        available: false,
+        error: 'page rendering unavailable',
+        details: {
+          unpdf: true,
+          pageRendering: false,
+          ocr: true,
+          ocrProviders: 1,
+        },
+      });
+    const kreuzbergDepsSpy = vi
+      .spyOn(KreuzbergProvider.prototype, 'checkDependencies')
+      .mockResolvedValueOnce({
+        available: true,
+        details: {
+          kreuzberg: true,
+          ocrBackend: undefined,
+          ocrBackends: ['tesseract'],
+        },
+      });
+
+    try {
+      const reader = await getPDFReader({ provider: 'auto' });
+      expect(reader.constructor.name).toBe('KreuzbergProvider');
+    } finally {
+      combinedDepsSpy.mockRestore();
+      kreuzbergDepsSpy.mockRestore();
+    }
   });
 
   it('should route explicit onnx OCR requests to unpdf provider', async () => {

--- a/src/node/combined.test.ts
+++ b/src/node/combined.test.ts
@@ -194,6 +194,84 @@ describe('CombinedNodeProvider', () => {
     expect(reader.ocrFactory.performOCR).toHaveBeenCalledTimes(3);
   });
 
+  it('applies default OCR options during automatic OCR fallback', async () => {
+    const reader = new CombinedNodeProvider({
+      defaultOCROptions: {
+        language: 'fra',
+        confidenceThreshold: 72,
+      },
+    }) as any;
+
+    reader.unpdfProvider = {
+      extractText: vi.fn().mockResolvedValue(''),
+      renderPages: vi.fn().mockResolvedValue([
+        {
+          data: Buffer.from([1]),
+          format: 'rgb',
+          width: 10,
+          height: 10,
+          channels: 3,
+          pageNumber: 1,
+        },
+      ]),
+    };
+    reader.ocrFactory = {
+      performOCR: vi.fn().mockResolvedValue({
+        text: 'bonjour',
+        confidence: 95,
+      }),
+    };
+
+    await expect(reader.extractText('/tmp/scanned.pdf')).resolves.toBe(
+      'bonjour',
+    );
+    expect(reader.ocrFactory.performOCR).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({
+        language: 'fra',
+        confidenceThreshold: 72,
+      }),
+    );
+  });
+
+  it('merges explicit OCR options over configured defaults', async () => {
+    const reader = new CombinedNodeProvider({
+      defaultOCROptions: {
+        language: 'fra',
+        confidenceThreshold: 72,
+      },
+    }) as any;
+    reader.ocrFactory = {
+      performOCR: vi.fn().mockResolvedValue({
+        text: 'bonjour',
+        confidence: 95,
+      }),
+    };
+
+    await reader.performOCR(
+      [
+        {
+          data: Buffer.from([1]),
+          format: 'rgb',
+          width: 10,
+          height: 10,
+          channels: 3,
+        },
+      ],
+      {
+        language: 'eng',
+      },
+    );
+
+    expect(reader.ocrFactory.performOCR).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({
+        language: 'eng',
+        confidenceThreshold: 72,
+      }),
+    );
+  });
+
   it('respects skipOCRFallback for large OCR-recommended PDFs', async () => {
     const reader = new CombinedNodeProvider() as any;
     reader.getSourceByteLength = vi.fn().mockResolvedValue(32 * 1024 * 1024);

--- a/src/node/combined.ts
+++ b/src/node/combined.ts
@@ -39,13 +39,32 @@ export class CombinedNodeProvider extends BasePDFReader {
   protected name = 'combined-node';
   private unpdfProvider: UnpdfProvider;
   private ocrFactory: ReturnType<typeof getOCR>;
+  private defaultOCROptions?: OCROptions;
   private maxFileSize?: number;
 
-  constructor(options: { ocrProvider?: string; maxFileSize?: number } = {}) {
+  constructor(
+    options: {
+      ocrProvider?: string;
+      defaultOCROptions?: OCROptions;
+      maxFileSize?: number;
+    } = {},
+  ) {
     super();
     this.unpdfProvider = new UnpdfProvider();
     this.ocrFactory = getOCR({ provider: options.ocrProvider || 'auto' });
+    this.defaultOCROptions = options.defaultOCROptions;
     this.maxFileSize = options.maxFileSize;
+  }
+
+  private mergeOCROptions(options?: OCROptions): OCROptions | undefined {
+    if (!this.defaultOCROptions && !options) {
+      return undefined;
+    }
+
+    return {
+      ...(this.defaultOCROptions || {}),
+      ...(options || {}),
+    };
   }
 
   private isInvalidSource(source: PDFSource): boolean {
@@ -221,7 +240,7 @@ export class CombinedNodeProvider extends BasePDFReader {
       };
     }
 
-    return this.ocrFactory.performOCR(renderedPages);
+    return this.ocrFactory.performOCR(renderedPages, this.mergeOCROptions());
   }
 
   private async extractOcrBatchText(
@@ -377,7 +396,10 @@ export class CombinedNodeProvider extends BasePDFReader {
           });
 
           if (renderedPages && renderedPages.length > 0) {
-            const ocrResult = await this.ocrFactory.performOCR(renderedPages);
+            const ocrResult = await this.ocrFactory.performOCR(
+              renderedPages,
+              this.mergeOCROptions(),
+            );
             return ocrResult.text || null;
           }
         } catch (ocrError) {
@@ -430,7 +452,7 @@ export class CombinedNodeProvider extends BasePDFReader {
     images: PDFImage[],
     options?: OCROptions,
   ): Promise<OCRResult> {
-    return this.ocrFactory.performOCR(images, options);
+    return this.ocrFactory.performOCR(images, this.mergeOCROptions(options));
   }
 
   /**

--- a/src/ocr-integration.test.ts
+++ b/src/ocr-integration.test.ts
@@ -14,7 +14,7 @@ describe.skipIf(process.env.CI === 'true')(
     const originalTessdataPrefix = process.env.TESSDATA_PREFIX;
 
     beforeAll(async () => {
-      // Default reader (kreuzberg if available)
+      // Default reader (combined Node provider)
       reader = await getPDFReader();
       onnxReader = await getPDFReader({
         provider: 'auto',

--- a/src/shared/factory.ts
+++ b/src/shared/factory.ts
@@ -7,18 +7,6 @@ import type { PDFReader, PDFReaderOptions } from './types';
 
 type RuntimeProvider = NonNullable<PDFReaderOptions['provider']>;
 
-/**
- * Check if the kreuzberg provider is available (optional dependency)
- */
-async function isKreuzbergAvailable(): Promise<boolean> {
-  try {
-    await import('@kreuzberg/node');
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 function requiresExternalOCRProvider(ocrProvider?: string): boolean {
   return Boolean(
     ocrProvider && ocrProvider !== 'auto' && ocrProvider !== 'tesseract',
@@ -50,24 +38,6 @@ function isRuntimeProvider(value: string): value is RuntimeProvider {
   );
 }
 
-async function canUseKreuzberg(options: PDFReaderOptions): Promise<boolean> {
-  if (!(await isKreuzbergAvailable())) {
-    return false;
-  }
-
-  try {
-    const { KreuzbergProvider } = await import('../node/kreuzberg.js');
-    const reader = new KreuzbergProvider({
-      ocrBackend: options.ocrProvider,
-      ocrLanguage: options.defaultOCROptions?.language,
-    });
-    const deps = await reader.checkDependencies();
-    return deps.available;
-  } catch {
-    return false;
-  }
-}
-
 /**
  * Create a PDF reader instance with intelligent provider selection and configuration
  *
@@ -85,7 +55,7 @@ async function canUseKreuzberg(options: PDFReaderOptions): Promise<boolean> {
  * @example
  * ```typescript
  * // Auto-detect best provider for current environment
- * // In Node.js: uses kreuzberg if available, else unpdf
+ * // In Node.js: uses the combined provider so text, images, and OCR stay coherent
  * const reader = await getPDFReader();
  *
  * // Configure with specific options
@@ -160,14 +130,7 @@ export async function getPDFReader(
   let selectedProvider = provider;
   if (provider === 'auto') {
     if (isNode) {
-      // Route non-Tesseract OCR providers through the unpdf + @happyvertical/ocr path.
-      if (requiresExternalOCRProvider(readerOptions.ocrProvider)) {
-        selectedProvider = 'unpdf';
-      } else {
-        selectedProvider = (await canUseKreuzberg(readerOptions))
-          ? 'kreuzberg'
-          : 'unpdf';
-      }
+      selectedProvider = 'unpdf';
     } else if (isBrowser) {
       selectedProvider = 'pdfjs'; // Use PDF.js for browser
     } else {
@@ -186,7 +149,9 @@ export async function getPDFReader(
         );
       }
 
-      // Dynamic import to avoid bundling Node.js code in browser
+      // Dynamic import to avoid bundling Node.js code in browser.
+      // The combined Node provider keeps modular operations like extractImages()
+      // available even when callers start from provider: 'auto'.
       const { CombinedNodeProvider } = await import('../node/combined.js');
       return new CombinedNodeProvider({
         ocrProvider: readerOptions.ocrProvider as string | undefined,

--- a/src/shared/factory.ts
+++ b/src/shared/factory.ts
@@ -7,6 +7,15 @@ import type { PDFReader, PDFReaderOptions } from './types';
 
 type RuntimeProvider = NonNullable<PDFReaderOptions['provider']>;
 
+async function isKreuzbergAvailable(): Promise<boolean> {
+  try {
+    await import('@kreuzberg/node');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function requiresExternalOCRProvider(ocrProvider?: string): boolean {
   return Boolean(
     ocrProvider && ocrProvider !== 'auto' && ocrProvider !== 'tesseract',
@@ -36,6 +45,42 @@ function isRuntimeProvider(value: string): value is RuntimeProvider {
     value === 'pdfjs' ||
     value === 'kreuzberg'
   );
+}
+
+async function canUseCombinedNodeProvider(
+  options: PDFReaderOptions,
+): Promise<boolean> {
+  try {
+    const { CombinedNodeProvider } = await import('../node/combined.js');
+    const reader = new CombinedNodeProvider({
+      ocrProvider: options.ocrProvider,
+      defaultOCROptions: options.defaultOCROptions,
+      maxFileSize: options.maxFileSize,
+    });
+    const deps = await reader.checkDependencies();
+    return deps.available;
+  } catch {
+    return false;
+  }
+}
+
+async function canUseKreuzberg(options: PDFReaderOptions): Promise<boolean> {
+  if (!(await isKreuzbergAvailable())) {
+    return false;
+  }
+
+  try {
+    const { KreuzbergProvider } = await import('../node/kreuzberg.js');
+    const reader = new KreuzbergProvider({
+      ocrBackend: options.ocrProvider,
+      ocrLanguage: options.defaultOCROptions?.language,
+      maxFileSize: options.maxFileSize,
+    });
+    const deps = await reader.checkDependencies();
+    return deps.available;
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -130,7 +175,15 @@ export async function getPDFReader(
   let selectedProvider = provider;
   if (provider === 'auto') {
     if (isNode) {
-      selectedProvider = 'unpdf';
+      if (requiresExternalOCRProvider(readerOptions.ocrProvider)) {
+        selectedProvider = 'unpdf';
+      } else if (await canUseCombinedNodeProvider(readerOptions)) {
+        selectedProvider = 'unpdf';
+      } else if (await canUseKreuzberg(readerOptions)) {
+        selectedProvider = 'kreuzberg';
+      } else {
+        selectedProvider = 'unpdf';
+      }
     } else if (isBrowser) {
       selectedProvider = 'pdfjs'; // Use PDF.js for browser
     } else {
@@ -155,6 +208,7 @@ export async function getPDFReader(
       const { CombinedNodeProvider } = await import('../node/combined.js');
       return new CombinedNodeProvider({
         ocrProvider: readerOptions.ocrProvider as string | undefined,
+        defaultOCROptions: readerOptions.defaultOCROptions,
         maxFileSize: readerOptions.maxFileSize,
       });
     }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -159,7 +159,7 @@ export interface PDFCapabilities {
  *
  * Controls provider selection, OCR behavior, and processing limits. The 'auto'
  * provider setting automatically selects the best available provider for the
- * current environment (unpdf for Node.js, PDF.js for browsers).
+ * current environment (the combined Node reader in Node.js, PDF.js in browsers).
  *
  * @example
  * ```typescript


### PR DESCRIPTION
## Summary
- keep Node `provider: "auto"` on the combined reader so modular operations like `extractImages()` continue to work
- add regressions covering auto-reader image extraction and capability reporting
- update docs/comments to reflect the combined auto-reader contract

## Testing
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm exec vitest run src/factory.test.ts src/extraction.test.ts