### PR TITLE
fix(pdf): align OCR test timeouts with CI budget

### DIFF
--- a/src/extraction.test.ts
+++ b/src/extraction.test.ts
@@ -4,6 +4,8 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { getPDFReader } from './index';
 import type { PDFReader } from './shared/types';
 
+const OCR_TEST_TIMEOUT_MS = 120000;
+
 describe('PDF Content Extraction', () => {
   let reader: PDFReader;
   let unpdfReader: PDFReader;
@@ -64,17 +66,21 @@ describe('PDF Content Extraction', () => {
     }
   });
 
-  it('should extract text from scanned PDF via OCR fallback', async () => {
-    const text = await reader.extractText(pdfPath);
+  it(
+    'should extract text from scanned PDF via OCR fallback',
+    async () => {
+      const text = await reader.extractText(pdfPath);
 
-    // Must successfully extract text, not return null
-    expect(text).not.toBeNull();
-    expect(typeof text).toBe('string');
+      // Must successfully extract text, not return null
+      expect(text).not.toBeNull();
+      expect(typeof text).toBe('string');
 
-    // Must extract meaningful content from 3-page document
-    expect(text?.length).toBeGreaterThan(100);
+      // Must extract meaningful content from 3-page document
+      expect(text?.length).toBeGreaterThan(100);
 
-    // Should contain "Bentley" (the town name in the document)
-    expect(text?.toLowerCase()).toContain('bentley');
-  }, 60000);
+      // Should contain "Bentley" (the town name in the document)
+      expect(text?.toLowerCase()).toContain('bentley');
+    },
+    OCR_TEST_TIMEOUT_MS,
+  );
 });

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -7,6 +7,8 @@ import {
   getPDFReader,
 } from './index';
 
+const OCR_TEST_TIMEOUT_MS = 120000;
+
 describe('PDF Package Integration', () => {
   let reader: any = null;
 
@@ -35,19 +37,23 @@ describe('PDF Package Integration', () => {
     );
   }, 30000);
 
-  it('should extract text using legacy function', async () => {
-    const pdfPath = join(
-      fileURLToPath(new URL('.', import.meta.url)),
-      '..',
-      'test',
-      'Signed-Meeting-Minutes-October-8-2024-Regular-Council-Meeting-1.pdf',
-    );
+  it(
+    'should extract text using legacy function',
+    async () => {
+      const pdfPath = join(
+        fileURLToPath(new URL('.', import.meta.url)),
+        '..',
+        'test',
+        'Signed-Meeting-Minutes-October-8-2024-Regular-Council-Meeting-1.pdf',
+      );
 
-    const text = await extractTextFromPDF(pdfPath);
+      const text = await extractTextFromPDF(pdfPath);
 
-    expect(text !== undefined).toBe(true);
-    expect(typeof text === 'string' || text === null).toBe(true);
-  }, 60000); // 60 second timeout for OCR processing
+      expect(text !== undefined).toBe(true);
+      expect(typeof text === 'string' || text === null).toBe(true);
+    },
+    OCR_TEST_TIMEOUT_MS,
+  );
 
   it('should check OCR dependencies', async () => {
     const deps = await checkOCRDependencies();

--- a/src/legacy.test.ts
+++ b/src/legacy.test.ts
@@ -9,21 +9,27 @@ import {
   performOCROnImages,
 } from './index';
 
+const OCR_TEST_TIMEOUT_MS = 120000;
+
 describe('Legacy Compatibility Functions', () => {
-  it('should extract text using legacy function', async () => {
-    const pdfPath = join(
-      fileURLToPath(new URL('.', import.meta.url)),
-      '..',
-      'test',
-      'Signed-Meeting-Minutes-October-8-2024-Regular-Council-Meeting-1.pdf',
-    );
+  it(
+    'should extract text using legacy function',
+    async () => {
+      const pdfPath = join(
+        fileURLToPath(new URL('.', import.meta.url)),
+        '..',
+        'test',
+        'Signed-Meeting-Minutes-October-8-2024-Regular-Council-Meeting-1.pdf',
+      );
 
-    const text = await extractTextFromPDF(pdfPath);
+      const text = await extractTextFromPDF(pdfPath);
 
-    // Should behave exactly like the original function
-    expect(text !== undefined).toBe(true);
-    expect(typeof text === 'string' || text === null).toBe(true);
-  }, 60000); // 60 second timeout for OCR processing
+      // Should behave exactly like the original function
+      expect(text !== undefined).toBe(true);
+      expect(typeof text === 'string' || text === null).toBe(true);
+    },
+    OCR_TEST_TIMEOUT_MS,
+  );
 
   it('should extract images using legacy function (unpdf provider)', async () => {
     const pdfPath = join(


### PR DESCRIPTION
## Summary
- align the OCR-heavy test cases with the package's 120s Vitest budget
- stop the release-unblocker path from failing early at 60s on CI runners
- keep the change test-only so the next main push can publish the already-merged PDF fixes

## Verification
- pnpm lint
- pnpm typecheck
- pnpm test