### PR TITLE
[codex] Bound extractImages memory for large PDFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,16 @@ console.log(`Created: ${metadata.creationDate}`);
 // Extract images for OCR or display
 const images = await reader.extractImages('/path/to/document.pdf');
 console.log(`Found ${images.length} images`);
+
+// Process large PDFs without retaining every image buffer
+await reader.extractImages('/path/to/large-document.pdf', {
+  batchSize: 4,
+  collect: false,
+  onBatch: async ({ images, pages }) => {
+    console.log(`Storing ${images.length} images from pages ${pages.join(', ')}`);
+    // Persist or OCR this batch here.
+  }
+});
 ```
 
 ### OCR Processing

--- a/package.json
+++ b/package.json
@@ -15,11 +15,7 @@
       "pdfjs-dist": "5.4.296"
     }
   },
-  "files": [
-    "dist",
-    "README.md",
-    "LICENSE"
-  ],
+  "files": ["dist", "README.md", "LICENSE"],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com",
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/pdf",
-  "version": "0.62.24",
+  "version": "0.62.25",
   "description": "Modern PDF processing utilities with text extraction and OCR support using unpdf and @happyvertical/ocr",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/browser/combined.ts
+++ b/src/browser/combined.ts
@@ -6,6 +6,7 @@ import { getOCR } from '@happyvertical/ocr';
 import { BasePDFReader } from '../shared/base';
 import type {
   DependencyCheckResult,
+  ExtractImagesOptions,
   ExtractTextOptions,
   OCROptions,
   OCRResult,
@@ -78,8 +79,11 @@ export class CombinedBrowserProvider extends BasePDFReader {
   /**
    * Extract images from a PDF using PDF.js
    */
-  async extractImages(source: PDFSource): Promise<PDFImage[]> {
-    return this.pdfjsProvider.extractImages(source);
+  async extractImages(
+    source: PDFSource,
+    options?: ExtractImagesOptions,
+  ): Promise<PDFImage[]> {
+    return this.pdfjsProvider.extractImages(source, options);
   }
 
   /**

--- a/src/browser/pdfjs.ts
+++ b/src/browser/pdfjs.ts
@@ -6,6 +6,7 @@ import type { TextItem } from 'pdfjs-dist/types/src/display/api';
 import { BasePDFReader } from '../shared/base';
 import type {
   DependencyCheckResult,
+  ExtractImagesOptions,
   ExtractTextOptions,
   PDFCapabilities,
   PDFImage,
@@ -185,7 +186,10 @@ export class PDFJSProvider extends BasePDFReader {
    * Extract images from a PDF using PDF.js
    * Note: PDF.js has limited image extraction capabilities compared to unpdf
    */
-  async extractImages(source: PDFSource): Promise<PDFImage[]> {
+  async extractImages(
+    source: PDFSource,
+    options?: ExtractImagesOptions,
+  ): Promise<PDFImage[]> {
     try {
       const pdfjs = await this.loadPDFJS();
       const typedArray = await this.normalizeSource(source);
@@ -197,8 +201,9 @@ export class PDFJSProvider extends BasePDFReader {
       const pdf = await pdfjs.getDocument({ data: typedArray }).promise;
       const allImages: PDFImage[] = [];
 
-      // Extract from all pages
-      for (let pageNum = 1; pageNum <= pdf.numPages; pageNum++) {
+      const pagesToExtract = this.normalizePages(options?.pages, pdf.numPages);
+
+      for (const pageNum of pagesToExtract) {
         try {
           const page = await pdf.getPage(pageNum);
           await page.getOperatorList();

--- a/src/node/combined.test.ts
+++ b/src/node/combined.test.ts
@@ -505,4 +505,146 @@ describe('UnpdfProvider', () => {
       },
     });
   });
+
+  it('streams image batches without retaining previous batch images', async () => {
+    const reader = new UnpdfProvider() as any;
+    const documents: Array<{
+      cleanup: ReturnType<typeof vi.fn>;
+      destroy: ReturnType<typeof vi.fn>;
+    }> = [];
+    const getDocumentProxy = vi.fn().mockImplementation(async () => {
+      const document = {
+        numPages: 5,
+        cleanup: vi.fn(),
+        destroy: vi.fn(),
+      };
+      documents.push(document);
+      return document;
+    });
+
+    reader.loadUnpdf = vi.fn().mockResolvedValue({
+      getDocumentProxy,
+      extractImages: vi.fn().mockImplementation(async (_pdf, pageNumber) => [
+        {
+          data: Buffer.alloc(1024 * 1024, pageNumber),
+          width: 1,
+          height: 1024 * 1024,
+          channels: 1,
+        },
+      ]),
+    });
+    reader.normalizeSource = vi
+      .fn()
+      .mockResolvedValue(new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d]));
+    reader.validatePDFData = vi.fn().mockReturnValue(true);
+
+    const seenBatches: number[][] = [];
+    const result = await reader.extractImages('/tmp/large.pdf', {
+      batchSize: 2,
+      onBatch: async ({ images, pages, batchIndex, totalBatches }) => {
+        seenBatches.push(pages);
+        expect(images.map((image) => image.pageNumber)).toEqual(pages);
+        expect(batchIndex).toBe(seenBatches.length - 1);
+        expect(totalBatches).toBe(3);
+      },
+    });
+
+    expect(result).toEqual([]);
+    expect(seenBatches).toEqual([[1, 2], [3, 4], [5]]);
+    expect(getDocumentProxy).toHaveBeenCalledTimes(4);
+    for (const document of documents) {
+      expect(document.cleanup).toHaveBeenCalledOnce();
+      expect(document.destroy).toHaveBeenCalledOnce();
+    }
+  });
+
+  it('preserves page and image order across collected image batches', async () => {
+    const reader = new UnpdfProvider() as any;
+
+    reader.loadUnpdf = vi.fn().mockResolvedValue({
+      getDocumentProxy: vi.fn().mockResolvedValue({
+        numPages: 5,
+        cleanup: vi.fn(),
+        destroy: vi.fn(),
+      }),
+      extractImages: vi
+        .fn()
+        .mockImplementation(async (_pdf, pageNumber: number) => [
+          {
+            data: Buffer.from([pageNumber, 1]),
+            width: 1,
+            height: 2,
+            channels: 1,
+          },
+          {
+            data: Buffer.from([pageNumber, 2]),
+            width: 1,
+            height: 2,
+            channels: 1,
+          },
+        ]),
+    });
+    reader.normalizeSource = vi
+      .fn()
+      .mockResolvedValue(new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d]));
+    reader.validatePDFData = vi.fn().mockReturnValue(true);
+
+    const images = await reader.extractImages('/tmp/document.pdf', {
+      pages: [2, 4, 5],
+      batchSize: 2,
+    });
+
+    expect(images.map((image) => image.pageNumber)).toEqual([2, 2, 4, 4, 5, 5]);
+    expect(images.map((image) => [...image.data])).toEqual([
+      [2, 1],
+      [2, 2],
+      [4, 1],
+      [4, 2],
+      [5, 1],
+      [5, 2],
+    ]);
+  });
+
+  it('rejects explicit page decode failures during image batching', async () => {
+    const reader = new UnpdfProvider() as any;
+
+    reader.loadUnpdf = vi.fn().mockResolvedValue({
+      getDocumentProxy: vi.fn().mockResolvedValue({
+        numPages: 4,
+        cleanup: vi.fn(),
+        destroy: vi.fn(),
+      }),
+      extractImages: vi
+        .fn()
+        .mockImplementation(async (_pdf, pageNumber: number) => {
+          if (pageNumber === 3) {
+            throw new Error('decode failed');
+          }
+
+          return [
+            {
+              data: Buffer.from([pageNumber]),
+              width: 1,
+              height: 1,
+              channels: 1,
+            },
+          ];
+        }),
+    });
+    reader.normalizeSource = vi
+      .fn()
+      .mockResolvedValue(new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d]));
+    reader.validatePDFData = vi.fn().mockReturnValue(true);
+
+    const extractionPromise = reader.extractImages('/tmp/broken.pdf', {
+      batchSize: 2,
+    });
+
+    await expect(extractionPromise).rejects.toBeInstanceOf(
+      PDFBatchExtractionError,
+    );
+    await expect(extractionPromise).rejects.toThrow(
+      'Large PDF extraction failed for pages 3: decode failed',
+    );
+  });
 });

--- a/src/node/combined.test.ts
+++ b/src/node/combined.test.ts
@@ -558,6 +558,14 @@ describe('UnpdfProvider', () => {
     }
   });
 
+  it('returns an empty list for zero-length byte sources', async () => {
+    const reader = new UnpdfProvider() as any;
+    reader.loadUnpdf = vi.fn();
+
+    await expect(reader.extractImages(new Uint8Array())).resolves.toEqual([]);
+    expect(reader.loadUnpdf).not.toHaveBeenCalled();
+  });
+
   it('preserves page and image order across collected image batches', async () => {
     const reader = new UnpdfProvider() as any;
 
@@ -646,5 +654,40 @@ describe('UnpdfProvider', () => {
     await expect(extractionPromise).rejects.toThrow(
       'Large PDF extraction failed for pages 3: decode failed',
     );
+  });
+
+  it('preserves caller onBatch failures without remapping them', async () => {
+    const reader = new UnpdfProvider() as any;
+
+    reader.loadUnpdf = vi.fn().mockResolvedValue({
+      getDocumentProxy: vi.fn().mockResolvedValue({
+        numPages: 2,
+        cleanup: vi.fn(),
+        destroy: vi.fn(),
+      }),
+      extractImages: vi.fn().mockResolvedValue([
+        {
+          data: Buffer.from([1]),
+          width: 1,
+          height: 1,
+          channels: 1,
+        },
+      ]),
+    });
+    reader.normalizeSource = vi
+      .fn()
+      .mockResolvedValue(new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d]));
+    reader.validatePDFData = vi.fn().mockReturnValue(true);
+
+    const batchError = new Error('storage write failed');
+
+    await expect(
+      reader.extractImages('/tmp/document.pdf', {
+        batchSize: 1,
+        onBatch: async () => {
+          throw batchError;
+        },
+      }),
+    ).rejects.toBe(batchError);
   });
 });

--- a/src/node/combined.ts
+++ b/src/node/combined.ts
@@ -7,6 +7,7 @@ import { getOCR } from '@happyvertical/ocr';
 import { BasePDFReader } from '../shared/base';
 import type {
   DependencyCheckResult,
+  ExtractImagesOptions,
   ExtractTextOptions,
   OCROptions,
   OCRResult,
@@ -431,8 +432,18 @@ export class CombinedNodeProvider extends BasePDFReader {
   /**
    * Extract images from a PDF using unpdf
    */
-  async extractImages(source: PDFSource): Promise<PDFImage[]> {
-    return this.unpdfProvider.extractImages(source);
+  async extractImages(
+    source: PDFSource,
+    options?: ExtractImagesOptions,
+  ): Promise<PDFImage[]> {
+    if (this.isInvalidSource(source)) {
+      return [];
+    }
+
+    const sourceByteLength = await this.getSourceByteLength(source);
+    await this.assertWithinConfiguredMaxFileSize(source, sourceByteLength);
+
+    return this.unpdfProvider.extractImages(source, options);
   }
 
   /**

--- a/src/node/kreuzberg.ts
+++ b/src/node/kreuzberg.ts
@@ -9,6 +9,7 @@ import { promises as fs } from 'node:fs';
 import { BasePDFReader } from '../shared/base';
 import type {
   DependencyCheckResult,
+  ExtractImagesOptions,
   ExtractTextOptions,
   OCROptions,
   OCRResult,
@@ -323,7 +324,10 @@ export class KreuzbergProvider extends BasePDFReader {
    * Note: Kreuzberg focuses on text extraction with integrated OCR.
    * For standalone image extraction, use the unpdf provider.
    */
-  async extractImages(_source: PDFSource): Promise<PDFImage[]> {
+  async extractImages(
+    _source: PDFSource,
+    _options?: ExtractImagesOptions,
+  ): Promise<PDFImage[]> {
     // Kreuzberg doesn't expose image extraction separately
     // It handles OCR internally during text extraction
     throw new PDFUnsupportedError(

--- a/src/node/unpdf.ts
+++ b/src/node/unpdf.ts
@@ -306,15 +306,19 @@ export class UnpdfProvider extends BasePDFReader {
   }
 
   private isInvalidSource(source: PDFSource): boolean {
-    return (
-      !source ||
-      (typeof source === 'string' && source.trim() === '') ||
-      (typeof source === 'object' &&
-        Object.keys(source).length === 0 &&
-        !(source instanceof Buffer) &&
-        !(source instanceof ArrayBuffer) &&
-        !(source instanceof Uint8Array))
-    );
+    if (!source) {
+      return true;
+    }
+
+    if (typeof source === 'string') {
+      return source.trim() === '';
+    }
+
+    if (source instanceof Uint8Array || source instanceof ArrayBuffer) {
+      return source.byteLength === 0;
+    }
+
+    return typeof source === 'object' && Object.keys(source).length === 0;
   }
 
   private normalizeImageBatchSize(batchSize?: number): number {
@@ -482,21 +486,10 @@ export class UnpdfProvider extends BasePDFReader {
     const allImages: PDFImage[] = [];
 
     for (const [batchIndex, pages] of batches.entries()) {
+      let images: PDFImage[];
+
       try {
-        const images = await this.extractImageBatch(unpdf, source, pages);
-
-        await options?.onBatch?.({
-          images,
-          pages,
-          batchIndex,
-          totalBatches: batches.length,
-        });
-
-        if (shouldCollect) {
-          for (const image of images) {
-            allImages.push(image);
-          }
-        }
+        images = await this.extractImageBatch(unpdf, source, pages);
       } catch (error) {
         if (error instanceof PDFBatchExtractionError) {
           throw error;
@@ -504,6 +497,19 @@ export class UnpdfProvider extends BasePDFReader {
 
         const message = error instanceof Error ? error.message : String(error);
         throw new PDFBatchExtractionError(pages, message);
+      }
+
+      await options?.onBatch?.({
+        images,
+        pages,
+        batchIndex,
+        totalBatches: batches.length,
+      });
+
+      if (shouldCollect) {
+        for (const image of images) {
+          allImages.push(image);
+        }
       }
     }
 

--- a/src/node/unpdf.ts
+++ b/src/node/unpdf.ts
@@ -18,6 +18,7 @@ import type {
 import { BasePDFReader } from '../shared/base';
 import type {
   DependencyCheckResult,
+  ExtractImagesOptions,
   ExtractTextOptions,
   PDFCapabilities,
   PDFImage,
@@ -26,12 +27,20 @@ import type {
   PDFSource,
   RenderPagesOptions,
 } from '../shared/types';
-import { PDFDependencyError } from '../shared/types';
+import { PDFBatchExtractionError, PDFDependencyError } from '../shared/types';
 import { formatPdfOcrRuntimeIssue } from './ocr-runtime';
 
 const require = createRequire(import.meta.url);
+const IMAGE_EXTRACTION_BATCH_SIZE = 4;
 
 type UnpdfModule = typeof import('unpdf');
+type UnpdfDocumentProxy = Awaited<ReturnType<UnpdfModule['getDocumentProxy']>>;
+type UnpdfExtractedImage = {
+  data: Buffer | Uint8Array | Uint8ClampedArray | ArrayBuffer;
+  width?: number;
+  height?: number;
+  channels?: number;
+};
 type TextMarkedContent = { type: string; id: string };
 type NodeRenderableContext = NapiCanvasRenderingContext2D | SKRSContext2D;
 type PDFMetadataInfo = Record<string, unknown>;
@@ -186,6 +195,7 @@ export class UnpdfProvider extends BasePDFReader {
       (typeof source === 'object' &&
         Object.keys(source).length === 0 &&
         !(source instanceof Buffer) &&
+        !(source instanceof ArrayBuffer) &&
         !(source instanceof Uint8Array))
     ) {
       return null;
@@ -295,84 +305,209 @@ export class UnpdfProvider extends BasePDFReader {
     return rgbData;
   }
 
-  /**
-   * Extract images from a PDF using unpdf
-   */
-  async extractImages(source: PDFSource): Promise<PDFImage[]> {
-    // Handle invalid inputs gracefully
-    if (
+  private isInvalidSource(source: PDFSource): boolean {
+    return (
       !source ||
       (typeof source === 'string' && source.trim() === '') ||
       (typeof source === 'object' &&
         Object.keys(source).length === 0 &&
         !(source instanceof Buffer) &&
+        !(source instanceof ArrayBuffer) &&
         !(source instanceof Uint8Array))
-    ) {
-      return [];
+    );
+  }
+
+  private normalizeImageBatchSize(batchSize?: number): number {
+    if (!batchSize || !Number.isFinite(batchSize) || batchSize < 1) {
+      return IMAGE_EXTRACTION_BATCH_SIZE;
+    }
+
+    return Math.floor(batchSize);
+  }
+
+  private chunkPages(pages: number[], batchSize: number): number[][] {
+    const batches: number[][] = [];
+
+    for (let index = 0; index < pages.length; index += batchSize) {
+      batches.push(pages.slice(index, index + batchSize));
+    }
+
+    return batches;
+  }
+
+  private async loadPDFDocument(
+    unpdf: UnpdfModule,
+    source: PDFSource,
+  ): Promise<UnpdfDocumentProxy> {
+    const buffer = await this.normalizeSource(source);
+
+    if (!this.validatePDFData(buffer)) {
+      throw new Error('Invalid PDF data');
+    }
+
+    // Clone in-memory sources so PDF.js worker transfer does not detach caller-owned buffers.
+    const documentData =
+      typeof source === 'string' ? buffer : new Uint8Array(buffer);
+    return unpdf.getDocumentProxy(documentData);
+  }
+
+  private async closePDFDocument(pdf: UnpdfDocumentProxy): Promise<void> {
+    try {
+      await pdf.cleanup?.();
+    } catch {
+      // Best-effort cleanup; destroy below is the important release path.
     }
 
     try {
-      const unpdf = await this.loadUnpdf();
-      const buffer = await this.normalizeSource(source);
+      await pdf.destroy?.();
+    } catch {
+      // Ignore cleanup failures so extraction errors remain the caller-visible failure.
+    }
+  }
 
-      if (!this.validatePDFData(buffer)) {
-        throw new Error('Invalid PDF data');
+  private async getPageCount(
+    unpdf: UnpdfModule,
+    source: PDFSource,
+  ): Promise<number> {
+    const pdf = await this.loadPDFDocument(unpdf, source);
+
+    try {
+      return pdf.numPages;
+    } finally {
+      await this.closePDFDocument(pdf);
+    }
+  }
+
+  private convertExtractedImage(
+    image: UnpdfExtractedImage,
+    pageNumber: number,
+  ): PDFImage {
+    const rawData = this.convertImageDataToBuffer(image.data);
+
+    // Direct RGB data processing - optimal path for OCR
+    let processedData: Buffer = rawData;
+    let format = 'unknown';
+
+    // If we have raw RGB data (3 channels), keep it as raw RGB
+    if (image.channels === 3 && image.width && image.height) {
+      const expectedSize = image.width * image.height * 3;
+      if (rawData.length === expectedSize) {
+        processedData = this.processRawRGBData(
+          rawData,
+          image.width,
+          image.height,
+        );
+        format = 'rgb'; // Mark as raw RGB for OCR to recognize optimal path
       }
+    }
 
-      const pdf = await unpdf.getDocumentProxy(buffer);
-      const allImages: PDFImage[] = [];
+    return {
+      data: processedData,
+      width: image.width,
+      height: image.height,
+      channels: image.channels,
+      format,
+      pageNumber,
+    };
+  }
 
-      // Extract from all pages
-      for (let pageNum = 1; pageNum <= pdf.numPages; pageNum++) {
+  private convertImageDataToBuffer(data: UnpdfExtractedImage['data']): Buffer {
+    if (data instanceof Buffer) {
+      return data;
+    }
+
+    if (data instanceof ArrayBuffer) {
+      return Buffer.from(data);
+    }
+
+    return Buffer.from(data);
+  }
+
+  private async extractImageBatch(
+    unpdf: UnpdfModule,
+    source: PDFSource,
+    pages: number[],
+  ): Promise<PDFImage[]> {
+    const pdf = await this.loadPDFDocument(unpdf, source);
+    const batchImages: PDFImage[] = [];
+
+    try {
+      for (const pageNum of pages) {
         try {
           const images = await unpdf.extractImages(pdf, pageNum);
 
-          // Convert unpdf image format to our PDFImage format with BMP conversion
           for (const image of images) {
-            const rawData: Buffer =
-              image.data instanceof Buffer
-                ? image.data
-                : Buffer.from(image.data);
-
-            // Direct RGB data processing - optimal path for OCR
-            let processedData: Buffer = rawData;
-            let format = 'unknown';
-
-            // If we have raw RGB data (3 channels), keep it as raw RGB
-            if (image.channels === 3 && image.width && image.height) {
-              const expectedSize = image.width * image.height * 3;
-              if (rawData.length === expectedSize) {
-                processedData = this.processRawRGBData(
-                  rawData,
-                  image.width,
-                  image.height,
-                );
-                format = 'rgb'; // Mark as raw RGB for OCR to recognize optimal path
-              }
-            }
-
-            allImages.push({
-              data: processedData,
-              width: image.width,
-              height: image.height,
-              channels: image.channels,
-              format: format,
-              pageNumber: pageNum,
-            });
+            batchImages.push(
+              this.convertExtractedImage(image as UnpdfExtractedImage, pageNum),
+            );
           }
         } catch (pageError) {
-          console.warn(
-            `Failed to extract images from page ${pageNum}:`,
-            pageError,
-          );
+          const message =
+            pageError instanceof Error ? pageError.message : String(pageError);
+          throw new PDFBatchExtractionError([pageNum], message);
         }
       }
 
-      return allImages;
-    } catch (error) {
-      console.error('unpdf image extraction failed:', error);
+      return batchImages;
+    } finally {
+      await this.closePDFDocument(pdf);
+    }
+  }
+
+  /**
+   * Extract images from a PDF using unpdf
+   */
+  async extractImages(
+    source: PDFSource,
+    options?: ExtractImagesOptions,
+  ): Promise<PDFImage[]> {
+    // Handle invalid inputs gracefully
+    if (this.isInvalidSource(source)) {
       return [];
     }
+
+    const unpdf = await this.loadUnpdf();
+    const totalPages = await this.getPageCount(unpdf, source);
+    const pagesToExtract = this.normalizePages(options?.pages, totalPages);
+
+    if (pagesToExtract.length === 0) {
+      return [];
+    }
+
+    const batches = this.chunkPages(
+      pagesToExtract,
+      this.normalizeImageBatchSize(options?.batchSize),
+    );
+    const shouldCollect = options?.collect ?? !options?.onBatch;
+    const allImages: PDFImage[] = [];
+
+    for (const [batchIndex, pages] of batches.entries()) {
+      try {
+        const images = await this.extractImageBatch(unpdf, source, pages);
+
+        await options?.onBatch?.({
+          images,
+          pages,
+          batchIndex,
+          totalBatches: batches.length,
+        });
+
+        if (shouldCollect) {
+          for (const image of images) {
+            allImages.push(image);
+          }
+        }
+      } catch (error) {
+        if (error instanceof PDFBatchExtractionError) {
+          throw error;
+        }
+
+        const message = error instanceof Error ? error.message : String(error);
+        throw new PDFBatchExtractionError(pages, message);
+      }
+    }
+
+    return allImages;
   }
 
   /**

--- a/src/shared/base.ts
+++ b/src/shared/base.ts
@@ -4,6 +4,7 @@
 
 import type {
   DependencyCheckResult,
+  ExtractImagesOptions,
   ExtractTextOptions,
   OCROptions,
   OCRResult,
@@ -88,7 +89,10 @@ export abstract class BasePDFReader implements PDFReader {
    * @returns Promise resolving to array of extracted image objects
    * @throws {PDFUnsupportedError} When provider doesn't support image extraction
    */
-  async extractImages(_source: PDFSource): Promise<PDFImage[]> {
+  async extractImages(
+    _source: PDFSource,
+    _options?: ExtractImagesOptions,
+  ): Promise<PDFImage[]> {
     throw new PDFUnsupportedError(`extractImages (provider: ${this.name})`);
   }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -114,6 +114,44 @@ export interface PDFImage extends BaseOCRImage {
   pageNumber?: number;
 }
 
+/**
+ * A page-bounded image extraction batch delivered to streaming callers
+ */
+export interface PDFImageBatch {
+  /** Images extracted from this batch, in page/image order */
+  images: PDFImage[];
+  /** Page numbers included in this batch (1-based) */
+  pages: number[];
+  /** Zero-based batch index */
+  batchIndex: number;
+  /** Total number of batches for this extraction request */
+  totalBatches: number;
+}
+
+/**
+ * Configuration options for extracting embedded images from PDF documents
+ */
+export interface ExtractImagesOptions {
+  /** Specific pages to extract (1-based indexing). If not provided, extracts all pages */
+  pages?: number[];
+  /** Number of pages to process per provider batch. Defaults to a small bounded batch size */
+  batchSize?: number;
+  /**
+   * Whether to accumulate extracted images into the returned array.
+   *
+   * Defaults to true for ordinary extractImages() calls, and false when onBatch is
+   * provided so streaming callers do not retain previous image buffers.
+   */
+  collect?: boolean;
+  /**
+   * Receives each completed page batch before the next batch starts.
+   *
+   * Use this to persist or OCR images incrementally without keeping the whole
+   * document's image bytes in memory.
+   */
+  onBatch?: (batch: PDFImageBatch) => void | Promise<void>;
+}
+
 // Re-export OCR result type from the OCR package for backward compatibility
 export type { OCRResult } from '@happyvertical/ocr';
 
@@ -302,10 +340,11 @@ export interface PDFReader {
    * Extract all images from a PDF document for further processing or OCR
    *
    * Retrieves image data in a format suitable for OCR processing or display.
-   * Images include page number information for context. Returns empty array
-   * if no images are found or extraction fails.
+   * Images include page number information for context. Returns an empty array
+   * if no images are found.
    *
    * @param source - PDF source: file path (Node.js only), ArrayBuffer, or Uint8Array
+   * @param options - Image extraction configuration options
    * @returns Promise resolving to array of extracted PDFImage objects with raw data
    *
    * @throws {PDFUnsupportedError} When provider doesn't support image extraction
@@ -330,7 +369,10 @@ export interface PDFReader {
    * }
    * ```
    */
-  extractImages(source: string | ArrayBuffer | Uint8Array): Promise<PDFImage[]>;
+  extractImages(
+    source: string | ArrayBuffer | Uint8Array,
+    options?: ExtractImagesOptions,
+  ): Promise<PDFImage[]>;
 
   /**
    * Render PDF pages as rasterized images for OCR processing


### PR DESCRIPTION
## Summary

Fixes #64.

- add page-scoped and batch-scoped options to `extractImages()`
- stream each image batch through `onBatch` so callers can persist/process images without retaining previous batch bytes
- release unpdf/pdf.js document resources between image batches and reject provider decode failures explicitly
- document the large-PDF batch usage pattern

## Root Cause

`extractImages()` walked the full PDF in one provider session and accumulated every extracted image buffer before returning. Large embedded-image PDFs could therefore retain unbounded image bytes and provider/page state until the entire document finished, which caused production OOMs before callers could persist derived assets.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm vitest run src/node/combined.test.ts --testTimeout 120000`
- `pnpm test`
- `pnpm build`
