### PR TITLE
ci(release): reject non-conventional squash commit titles

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -2,7 +2,7 @@ name: Changeset Check
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, labeled, unlabeled]
+    types: [opened, reopened, synchronize, edited, labeled, unlabeled]
 
 permissions:
   pull-requests: read
@@ -79,42 +79,23 @@ jobs:
             exit 0
           fi
 
-          # Check if PR has conventional commits that will trigger auto-changeset
+          # Squash merges publish from the PR title, so use that as the release source of truth.
           echo ""
-          echo "Checking for conventional commits..."
+          echo "Checking PR title for automatic release eligibility..."
 
-          # Get commits in this PR
-          BASE_SHA="${{ github.event.pull_request.base.sha }}"
-          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
-
-          # Check for releaseable conventional commits (feat, fix, perf, breaking changes)
-          RELEASEABLE_COMMITS=$(git log \
-            $BASE_SHA..$HEAD_SHA --pretty=format:"%s" --no-merges | \
-            grep -E '^(feat|fix|perf)(\(.+\))?!?:|BREAKING CHANGE' \
-            || true)
-
-          if [ -n "$RELEASEABLE_COMMITS" ]; then
-            echo "Found conventional commits that will trigger auto-changeset on merge:"
-            echo "$RELEASEABLE_COMMITS"
-            echo ""
-            echo "Validating changeset:auto script can generate changesets..."
-
-            # Run changeset:auto to validate it works (don't commit the result)
-            if pnpm run changeset:auto; then
-              echo "changeset:auto validation passed"
-              echo ""
-              echo "Generated changesets will be created automatically when this PR merges to main."
-              exit 0
-            else
-              echo "ERROR: changeset:auto script failed"
-              echo ""
-              echo "The auto-changeset generation script encountered an error."
-              echo "Please check the script or add a manual changeset."
-              exit 1
-            fi
+          if printf '%s\n' "$PR_TITLE" | grep -qE '^[a-z]+(\([^)]+\))?!:'; then
+            echo "PR title will trigger an automatic minor release on squash merge:"
+            echo "  $PR_TITLE"
+            exit 0
           fi
 
-          echo "No releaseable conventional commits found (feat, fix, perf, or breaking changes)"
+          if printf '%s\n' "$PR_TITLE" | grep -qE '^(feat|fix|perf)(\([^)]+\))?:|^chore\(deps\):'; then
+            echo "PR title will trigger an automatic patch release on squash merge:"
+            echo "  $PR_TITLE"
+            exit 0
+          fi
+
+          echo "PR title will not trigger an automatic release on squash merge"
           echo ""
 
           # Check if changeset files exist (excluding README.md)
@@ -125,6 +106,9 @@ jobs:
             echo ""
             echo "Please add a changeset by running:"
             echo "  npx changeset"
+            echo ""
+            echo "Or rename the PR to a releaseable conventional title like:"
+            echo "  fix(pdf): ..."
             echo ""
             echo "Or add the 'skip-changeset' label if this PR doesn't require a version bump"
             echo "(e.g., documentation changes, test updates, workflow changes)"

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -3,6 +3,7 @@ name: Pull Request Validation
 on:
   pull_request:
     branches: [main]
+    types: [opened, reopened, synchronize, edited]
 
 # Cancel in-progress runs when new commits are pushed
 concurrency:
@@ -11,6 +12,7 @@ concurrency:
 
 permissions:
   contents: read
+  packages: read
   pull-requests: write
 
 jobs:
@@ -24,27 +26,63 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Validate commit messages
-        uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          configFile: commitlint.config.js
+          node-version: '24'
+          registry-url: 'https://npm.pkg.github.com'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Setup pnpm cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate branch commit messages
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          bash scripts/validate-conventional-commits.sh range "$BASE_SHA" "$HEAD_SHA"
+
+      - name: Validate PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          bash scripts/validate-conventional-commits.sh title "$PR_TITLE"
 
       - name: Determine version bump
         id: version
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          commits=$(git log origin/main..HEAD --no-merges --pretty=format:"%s")
+          bump="none"
 
-          bump="patch"
-          if echo "$commits" | grep -qE "^feat(\(.+\))?!?:"; then
+          if printf '%s\n' "$PR_TITLE" | grep -qE '^[a-z]+(\([^)]+\))?!:'; then
             bump="minor"
           fi
 
-          if echo "$commits" | grep -qiE "(BREAKING CHANGE|!:)"; then
-            bump="minor"  # Treat as minor until 1.0.0
+          if [ "$bump" = "none" ] && printf '%s\n' "$PR_TITLE" | grep -qE '^(feat|fix|perf)(\([^)]+\))?:|^chore\(deps\):'; then
+            bump="patch"
           fi
 
           echo "bump=$bump" >> $GITHUB_OUTPUT
-          echo "Will perform $bump version bump on merge"
+          echo "PR title will perform a $bump version bump on squash merge"
 
       - name: Comment on PR
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
@@ -52,19 +90,27 @@ jobs:
           script: |
             const bump = '${{ steps.version.outputs.bump }}';
 
-            const comment = `## Version Bump Preview
+            const comment = bump === 'none'
+              ? `## Release Preview
 
-            When this PR is merged, @happyvertical/pdf will receive a **${bump}** version bump based on your conventional commits.
+            This PR title will **not** trigger an automatic release on squash merge.
+
+            Use a releaseable conventional PR title like \`fix(pdf): ...\`, \`feat(pdf): ...\`, or \`chore(deps): ...\` if this change should publish automatically.
+
+            Otherwise, add a manual changeset or apply the \`skip-changeset\` label if no release is needed.`
+              : `## Release Preview
+
+            When this PR is squash-merged, @happyvertical/pdf will receive a **${bump}** version bump based on the PR title's conventional commit format.
 
             ### What happens on merge?
 
             1. Tests run on main branch
-            2. Package is built
+            2. The squash commit message is validated
             3. Version is bumped automatically
             4. Package is published to GitHub Packages
             5. Git tag is created
 
-            No manual intervention needed!`;
+            No manual intervention needed.`;
 
             // Check if we already commented
             const { data: comments } = await github.rest.issues.listComments({
@@ -75,7 +121,7 @@ jobs:
 
             const existingComment = comments.find(c =>
               c.user.login === 'github-actions[bot]' &&
-              c.body.includes('Version Bump Preview')
+              c.body.includes('Release Preview')
             );
 
             if (existingComment) {
@@ -96,4 +142,5 @@ jobs:
 
   test:
     name: Validate Changes
+    if: github.event.action != 'edited'
     uses: ./.github/workflows/test.yml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,6 +70,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+      - name: Validate triggering commit message
+        run: |
+          bash scripts/validate-conventional-commits.sh last
+
       - name: Validate version < 1.0.0
         run: |
           version=$(node -p "require('./package.json').version")

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -10,17 +10,19 @@ pre-commit:
       stage_fixed: true
 
 # Commit-msg hook: Validate commit message format
-# Skipped in CI to allow semantic-release commits
 commit-msg:
   commands:
     validate:
-      skip:
-        - run: "[ \"$CI\" = \"true\" ]"
-      run: npx --no-install commitlint --edit {1}
+      run: bash scripts/validate-conventional-commits.sh edit {1}
 
 # Pre-push hook: Run checks before pushing
 pre-push:
   commands:
+    conventional-commits:
+      run: bash scripts/validate-conventional-commits.sh upstream
+      skip:
+        - merge
+        - rebase
     typecheck:
       run: pnpm typecheck
       skip:

--- a/package.json
+++ b/package.json
@@ -15,11 +15,7 @@
       "pdfjs-dist": "5.4.296"
     }
   },
-  "files": [
-    "dist",
-    "README.md",
-    "LICENSE"
-  ],
+  "files": ["dist", "README.md", "LICENSE"],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com",
     "access": "public"

--- a/scripts/validate-conventional-commits.sh
+++ b/scripts/validate-conventional-commits.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/validate-conventional-commits.sh edit <commit-msg-file>
+  scripts/validate-conventional-commits.sh last
+  scripts/validate-conventional-commits.sh range <from> <to>
+  scripts/validate-conventional-commits.sh title <message>
+  scripts/validate-conventional-commits.sh upstream
+EOF
+}
+
+mode="${1:-}"
+
+if [ -z "$mode" ]; then
+  usage
+  exit 1
+fi
+
+shift
+
+commitlint() {
+  pnpm exec commitlint --strict --verbose "$@"
+}
+
+case "$mode" in
+  edit)
+    if [ "$#" -ne 1 ]; then
+      usage
+      exit 1
+    fi
+
+    commitlint --edit "$1"
+    ;;
+
+  last)
+    if [ "$#" -ne 0 ]; then
+      usage
+      exit 1
+    fi
+
+    commitlint --last
+    ;;
+
+  range)
+    if [ "$#" -ne 2 ]; then
+      usage
+      exit 1
+    fi
+
+    commitlint --from "$1" --to "$2" --git-log-args=--no-merges
+    ;;
+
+  title)
+    if [ "$#" -ne 1 ]; then
+      usage
+      exit 1
+    fi
+
+    printf '%s\n' "$1" | commitlint
+    ;;
+
+  upstream)
+    if [ "$#" -ne 0 ]; then
+      usage
+      exit 1
+    fi
+
+    upstream_ref="$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || true)"
+
+    if [ -z "$upstream_ref" ]; then
+      echo "No upstream branch found; validating the last commit instead."
+      commitlint --last
+      exit 0
+    fi
+
+    commitlint --from "$upstream_ref" --to HEAD --git-log-args=--no-merges
+    ;;
+
+  *)
+    usage
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary
- enforce conventional commit validation in local hooks and pre-push checks
- validate PR titles in CI because squash merges publish from the PR title
- fail the publish workflow early when the triggering main commit is not conventional

## Testing
- pnpm lint
- pnpm typecheck
- bash scripts/validate-conventional-commits.sh title "ci(release): enforce conventional squash commit titles"
- bash scripts/validate-conventional-commits.sh title "[codex] Bound extractImages memory for large PDFs" || true
- bash scripts/validate-conventional-commits.sh upstream