### PR TITLE
fix(pdf): node unpdf asset loading for image extraction

### DIFF
--- a/src/node/combined.test.ts
+++ b/src/node/combined.test.ts
@@ -488,6 +488,40 @@ describe('CombinedNodeProvider', () => {
 });
 
 describe('UnpdfProvider', () => {
+  it('configures unpdf to use the official pdfjs-dist legacy runtime', async () => {
+    const reader = new UnpdfProvider() as any;
+
+    reader.ensurePdfjsWorkerConfigured = vi.fn().mockResolvedValue(undefined);
+
+    const definePDFJSModule = vi
+      .fn()
+      .mockImplementation(async (resolver: () => Promise<unknown>) => {
+        const resolved = await resolver();
+        const expected = await import('pdfjs-dist/legacy/build/pdf.mjs');
+
+        expect(resolved).toBe(expected);
+      });
+
+    await reader.ensureUnpdfPdfjsRuntime({ definePDFJSModule });
+    await reader.ensureUnpdfPdfjsRuntime({ definePDFJSModule });
+
+    expect(definePDFJSModule).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves pdfjs asset directories as filesystem paths for Node', () => {
+    const reader = new UnpdfProvider() as any;
+
+    const options = reader.getPdfjsDocumentOptions();
+
+    expect(options).toMatchObject({
+      useWorkerFetch: false,
+      standardFontDataUrl: expect.stringMatching(/\/$/),
+      wasmUrl: expect.stringMatching(/\/$/),
+    });
+    expect(options.standardFontDataUrl).not.toMatch(/^file:\/\//);
+    expect(options.wasmUrl).not.toMatch(/^file:\/\//);
+  });
+
   it('should surface page rendering dependency failures', async () => {
     const reader = new UnpdfProvider() as any;
 
@@ -552,6 +586,15 @@ describe('UnpdfProvider', () => {
     expect(result).toEqual([]);
     expect(seenBatches).toEqual([[1, 2], [3, 4], [5]]);
     expect(getDocumentProxy).toHaveBeenCalledTimes(4);
+    for (const [, options] of getDocumentProxy.mock.calls) {
+      expect(options).toMatchObject({
+        useWorkerFetch: false,
+        standardFontDataUrl: expect.stringMatching(/\/$/),
+        wasmUrl: expect.stringMatching(/\/$/),
+      });
+      expect(options.standardFontDataUrl).not.toMatch(/^file:\/\//);
+      expect(options.wasmUrl).not.toMatch(/^file:\/\//);
+    }
     for (const document of documents) {
       expect(document.cleanup).toHaveBeenCalledOnce();
       expect(document.destroy).toHaveBeenCalledOnce();

--- a/src/node/combined.test.ts
+++ b/src/node/combined.test.ts
@@ -506,12 +506,13 @@ describe('UnpdfProvider', () => {
     await reader.ensureUnpdfPdfjsRuntime({ definePDFJSModule });
 
     expect(definePDFJSModule).toHaveBeenCalledTimes(1);
+    expect(reader.ensurePdfjsWorkerConfigured).not.toHaveBeenCalled();
   });
 
-  it('resolves pdfjs asset directories as filesystem paths for Node', () => {
+  it('resolves pdfjs asset directories as filesystem paths for Node rendering flows', () => {
     const reader = new UnpdfProvider() as any;
 
-    const options = reader.getPdfjsDocumentOptions();
+    const options = reader.getPdfjsDocumentOptions(true);
 
     expect(options).toMatchObject({
       useWorkerFetch: false,
@@ -520,6 +521,19 @@ describe('UnpdfProvider', () => {
     });
     expect(options.standardFontDataUrl).not.toMatch(/^file:\/\//);
     expect(options.wasmUrl).not.toMatch(/^file:\/\//);
+  });
+
+  it('tolerates missing optional pdfjs asset bundles', () => {
+    const reader = new UnpdfProvider() as any;
+
+    vi.spyOn(reader, 'resolveOptionalPdfjsAssetDirectory')
+      .mockReturnValueOnce(undefined)
+      .mockReturnValueOnce('/tmp/pdfjs-wasm/');
+
+    expect(reader.getPdfjsDocumentOptions(true)).toEqual({
+      useWorkerFetch: false,
+      wasmUrl: '/tmp/pdfjs-wasm/',
+    });
   });
 
   it('should surface page rendering dependency failures', async () => {
@@ -586,7 +600,10 @@ describe('UnpdfProvider', () => {
     expect(result).toEqual([]);
     expect(seenBatches).toEqual([[1, 2], [3, 4], [5]]);
     expect(getDocumentProxy).toHaveBeenCalledTimes(4);
-    for (const [, options] of getDocumentProxy.mock.calls) {
+    expect(getDocumentProxy.mock.calls[0]?.[1]).toEqual({
+      useWorkerFetch: false,
+    });
+    for (const [, options] of getDocumentProxy.mock.calls.slice(1)) {
       expect(options).toMatchObject({
         useWorkerFetch: false,
         standardFontDataUrl: expect.stringMatching(/\/$/),
@@ -599,6 +616,38 @@ describe('UnpdfProvider', () => {
       expect(document.cleanup).toHaveBeenCalledOnce();
       expect(document.destroy).toHaveBeenCalledOnce();
     }
+  });
+
+  it('passes file-backed getInfo sources through without forcing an extra buffer clone', async () => {
+    const reader = new UnpdfProvider() as any;
+    const unpdf = {};
+    const pdf = {
+      numPages: 1,
+      getMetadata: vi.fn().mockResolvedValue({ info: {} }),
+      getPage: vi.fn().mockResolvedValue({
+        getTextContent: vi.fn().mockResolvedValue({ items: [] }),
+        getOperatorList: vi.fn().mockResolvedValue({ fnArray: [] }),
+      }),
+      cleanup: vi.fn(),
+      destroy: vi.fn(),
+    };
+
+    reader.loadUnpdf = vi.fn().mockResolvedValue(unpdf);
+    reader.loadPDFDocument = vi.fn().mockResolvedValue(pdf);
+    reader.getSourceFileSize = vi.fn().mockResolvedValue(1234);
+
+    await expect(reader.getInfo('/tmp/document.pdf')).resolves.toMatchObject({
+      fileSize: 1234,
+      pageCount: 1,
+    });
+
+    expect(reader.loadPDFDocument).toHaveBeenCalledWith(
+      unpdf,
+      '/tmp/document.pdf',
+    );
+    expect(reader.getSourceFileSize).toHaveBeenCalledWith('/tmp/document.pdf');
+    expect(pdf.cleanup).toHaveBeenCalledOnce();
+    expect(pdf.destroy).toHaveBeenCalledOnce();
   });
 
   it('returns an empty list for zero-length byte sources', async () => {

--- a/src/node/unpdf.ts
+++ b/src/node/unpdf.ts
@@ -4,6 +4,7 @@
 
 import { promises as fs } from 'node:fs';
 import { createRequire } from 'node:module';
+import { dirname } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { Canvas } from '@napi-rs/canvas';
 import type {
@@ -11,6 +12,7 @@ import type {
   SKRSContext2D,
 } from '@napi-rs/canvas';
 import type {
+  DocumentInitParameters,
   PDFPageProxy,
   RenderParameters,
   TextItem,
@@ -88,7 +90,13 @@ function getMetadataInfoDate(
 export class UnpdfProvider extends BasePDFReader {
   protected name = 'unpdf';
   private unpdf: UnpdfModule | null = null;
+  private unpdfLoadPromise: Promise<UnpdfModule> | null = null;
   private configuredPdfjsWorkerSrc: string | null = null;
+  private hasConfiguredUnpdfPdfjsModule = false;
+  private pdfjsDocumentOptions: Pick<
+    DocumentInitParameters,
+    'standardFontDataUrl' | 'useWorkerFetch' | 'wasmUrl'
+  > | null = null;
 
   private rgbaToRgbBuffer(data: Uint8ClampedArray): Buffer {
     const rgbData = Buffer.alloc((data.length / 4) * 3);
@@ -114,12 +122,62 @@ export class UnpdfProvider extends BasePDFReader {
       return this.unpdf;
     }
 
+    if (!this.unpdfLoadPromise) {
+      this.unpdfLoadPromise = (async () => {
+        const unpdf = await import('unpdf');
+        await this.ensureUnpdfPdfjsRuntime(unpdf);
+        this.unpdf = unpdf;
+        return unpdf;
+      })();
+    }
+
     try {
-      this.unpdf = await import('unpdf');
-      return this.unpdf;
+      return await this.unpdfLoadPromise;
     } catch (error) {
+      this.unpdfLoadPromise = null;
+      this.unpdf = null;
       throw new PDFDependencyError('unpdf', (error as Error).message);
     }
+  }
+
+  private async ensureUnpdfPdfjsRuntime(
+    unpdf: Pick<UnpdfModule, 'definePDFJSModule'>,
+  ) {
+    if (!this.hasConfiguredUnpdfPdfjsModule) {
+      await unpdf.definePDFJSModule(
+        () => import('pdfjs-dist/legacy/build/pdf.mjs'),
+      );
+      this.hasConfiguredUnpdfPdfjsModule = true;
+    }
+
+    await this.ensurePdfjsWorkerConfigured();
+  }
+
+  private formatPdfjsAssetDirectory(path: string): string {
+    const normalized = path.replaceAll('\\', '/');
+    return normalized.endsWith('/') ? normalized : `${normalized}/`;
+  }
+
+  private getPdfjsDocumentOptions(): Pick<
+    DocumentInitParameters,
+    'standardFontDataUrl' | 'useWorkerFetch' | 'wasmUrl'
+  > {
+    if (!this.pdfjsDocumentOptions) {
+      const standardFontDataUrl = this.formatPdfjsAssetDirectory(
+        dirname(require.resolve('pdfjs-dist/standard_fonts/FoxitSymbol.pfb')),
+      );
+      const wasmUrl = this.formatPdfjsAssetDirectory(
+        dirname(require.resolve('pdfjs-dist/wasm/openjpeg.wasm')),
+      );
+
+      this.pdfjsDocumentOptions = {
+        standardFontDataUrl,
+        useWorkerFetch: false,
+        wasmUrl,
+      };
+    }
+
+    return this.pdfjsDocumentOptions;
   }
 
   private async ensurePdfjsWorkerConfigured() {
@@ -203,47 +261,49 @@ export class UnpdfProvider extends BasePDFReader {
 
     try {
       const unpdf = await this.loadUnpdf();
-      const buffer = await this.normalizeSource(source);
+      const pdf = await this.loadPDFDocument(unpdf, source);
 
-      if (!this.validatePDFData(buffer)) {
-        throw new Error('Invalid PDF data');
-      }
+      try {
+        const totalPages = pdf.numPages;
 
-      const pdf = await unpdf.getDocumentProxy(buffer);
-      const totalPages = pdf.numPages;
+        // Normalize pages to extract
+        const pagesToExtract = this.normalizePages(options?.pages, totalPages);
 
-      // Normalize pages to extract
-      const pagesToExtract = this.normalizePages(options?.pages, totalPages);
-
-      if (pagesToExtract.length === 0) {
-        return null;
-      }
-
-      // Extract text from specified pages
-      const pageTexts: string[] = [];
-
-      for (const pageNum of pagesToExtract) {
-        try {
-          const page = await pdf.getPage(pageNum);
-          const textContent = await page.getTextContent();
-
-          // Combine text items into a single string
-          const pageText = textContent.items.map(readTextItem).join(' ').trim();
-
-          pageTexts.push(pageText);
-        } catch (pageError) {
-          console.warn(
-            `Failed to extract text from page ${pageNum}:`,
-            pageError,
-          );
-          pageTexts.push(''); // Add empty string to maintain page order
+        if (pagesToExtract.length === 0) {
+          return null;
         }
+
+        // Extract text from specified pages
+        const pageTexts: string[] = [];
+
+        for (const pageNum of pagesToExtract) {
+          try {
+            const page = await pdf.getPage(pageNum);
+            const textContent = await page.getTextContent();
+
+            // Combine text items into a single string
+            const pageText = textContent.items
+              .map(readTextItem)
+              .join(' ')
+              .trim();
+
+            pageTexts.push(pageText);
+          } catch (pageError) {
+            console.warn(
+              `Failed to extract text from page ${pageNum}:`,
+              pageError,
+            );
+            pageTexts.push(''); // Add empty string to maintain page order
+          }
+        }
+
+        // Merge page texts according to options
+        const mergedText = this.mergePageTexts(pageTexts, options?.mergePages);
+
+        return mergedText || null;
+      } finally {
+        await this.closePDFDocument(pdf);
       }
-
-      // Merge page texts according to options
-      const mergedText = this.mergePageTexts(pageTexts, options?.mergePages);
-
-      return mergedText || null;
     } catch (error) {
       console.error('unpdf text extraction failed:', error);
       return null;
@@ -256,36 +316,40 @@ export class UnpdfProvider extends BasePDFReader {
   async extractMetadata(source: PDFSource): Promise<PDFMetadata> {
     try {
       const unpdf = await this.loadUnpdf();
-      const buffer = await this.normalizeSource(source);
+      const pdf = await this.loadPDFDocument(unpdf, source);
 
-      if (!this.validatePDFData(buffer)) {
-        throw new Error('Invalid PDF data');
+      try {
+        const metadata = await pdf.getMetadata();
+
+        return {
+          pageCount: pdf.numPages,
+          title: getMetadataInfoValue(metadata?.info, 'Title'),
+          author: getMetadataInfoValue(metadata?.info, 'Author'),
+          subject: getMetadataInfoValue(metadata?.info, 'Subject'),
+          keywords: getMetadataInfoValue(metadata?.info, 'Keywords'),
+          creationDate: getMetadataInfoDate(metadata?.info, 'CreationDate'),
+          modificationDate: getMetadataInfoDate(metadata?.info, 'ModDate'),
+          version: getMetadataInfoValue(metadata?.info, 'PDFFormatVersion'),
+          creator: getMetadataInfoValue(metadata?.info, 'Creator'),
+          producer: getMetadataInfoValue(metadata?.info, 'Producer'),
+          encrypted:
+            getMetadataInfoValue(metadata?.info, 'Encrypted') === 'Yes',
+        };
+      } finally {
+        await this.closePDFDocument(pdf);
       }
-
-      const pdf = await unpdf.getDocumentProxy(buffer);
-      const metadata = await pdf.getMetadata();
-
-      return {
-        pageCount: pdf.numPages,
-        title: getMetadataInfoValue(metadata?.info, 'Title'),
-        author: getMetadataInfoValue(metadata?.info, 'Author'),
-        subject: getMetadataInfoValue(metadata?.info, 'Subject'),
-        keywords: getMetadataInfoValue(metadata?.info, 'Keywords'),
-        creationDate: getMetadataInfoDate(metadata?.info, 'CreationDate'),
-        modificationDate: getMetadataInfoDate(metadata?.info, 'ModDate'),
-        version: getMetadataInfoValue(metadata?.info, 'PDFFormatVersion'),
-        creator: getMetadataInfoValue(metadata?.info, 'Creator'),
-        producer: getMetadataInfoValue(metadata?.info, 'Producer'),
-        encrypted: getMetadataInfoValue(metadata?.info, 'Encrypted') === 'Yes',
-      };
     } catch (error) {
       console.error('unpdf metadata extraction failed:', error);
       // Return default metadata with at least page count if possible
       try {
         const unpdf = await this.loadUnpdf();
-        const buffer = await this.normalizeSource(source);
-        const pdf = await unpdf.getDocumentProxy(buffer);
-        return this.createDefaultMetadata(pdf.numPages);
+        const pdf = await this.loadPDFDocument(unpdf, source);
+
+        try {
+          return this.createDefaultMetadata(pdf.numPages);
+        } finally {
+          await this.closePDFDocument(pdf);
+        }
       } catch {
         return this.createDefaultMetadata(0);
       }
@@ -352,7 +416,7 @@ export class UnpdfProvider extends BasePDFReader {
     // Clone in-memory sources so PDF.js worker transfer does not detach caller-owned buffers.
     const documentData =
       typeof source === 'string' ? buffer : new Uint8Array(buffer);
-    return unpdf.getDocumentProxy(documentData);
+    return unpdf.getDocumentProxy(documentData, this.getPdfjsDocumentOptions());
   }
 
   private async closePDFDocument(pdf: UnpdfDocumentProxy): Promise<void> {
@@ -667,107 +731,114 @@ export class UnpdfProvider extends BasePDFReader {
         throw new Error('Invalid PDF data');
       }
 
-      const pdf = await unpdf.getDocumentProxy(buffer);
-      const metadata = await pdf.getMetadata();
+      const pdf = await this.loadPDFDocument(unpdf, buffer);
 
-      // Quick analysis of document structure
-      const pageCount = pdf.numPages;
-      let hasEmbeddedText = false;
-      let hasImages = false;
-      let estimatedTextLength = 0;
+      try {
+        const metadata = await pdf.getMetadata();
 
-      // Sample first few pages to determine content type
-      const pagesToSample = Math.min(3, pageCount);
-      for (let i = 1; i <= pagesToSample; i++) {
-        try {
-          const page = await pdf.getPage(i);
-          const content = await page.getTextContent();
+        // Quick analysis of document structure
+        const pageCount = pdf.numPages;
+        let hasEmbeddedText = false;
+        let hasImages = false;
+        let estimatedTextLength = 0;
 
-          if (content.items && content.items.length > 0) {
-            hasEmbeddedText = true;
-            // Estimate text length based on sample
-            const pageTextLength = content.items.reduce(
-              (len: number, item: TextItem | TextMarkedContent) =>
-                len + readTextItem(item).length,
-              0,
-            );
-            estimatedTextLength += pageTextLength;
+        // Sample first few pages to determine content type
+        const pagesToSample = Math.min(3, pageCount);
+        for (let i = 1; i <= pagesToSample; i++) {
+          try {
+            const page = await pdf.getPage(i);
+            const content = await page.getTextContent();
+
+            if (content.items && content.items.length > 0) {
+              hasEmbeddedText = true;
+              // Estimate text length based on sample
+              const pageTextLength = content.items.reduce(
+                (len: number, item: TextItem | TextMarkedContent) =>
+                  len + readTextItem(item).length,
+                0,
+              );
+              estimatedTextLength += pageTextLength;
+            }
+
+            // Check for images (simplified check for rendering operations)
+            const ops = await page.getOperatorList();
+            if (ops.fnArray?.some((op: number) => op === 82 || op === 85)) {
+              // paintImageXObject operations
+              hasImages = true;
+            }
+          } catch (pageError) {
+            // Skip problematic pages
+            console.warn(`Failed to analyze page ${i}:`, pageError);
           }
-
-          // Check for images (simplified check for rendering operations)
-          const ops = await page.getOperatorList();
-          if (ops.fnArray?.some((op: number) => op === 82 || op === 85)) {
-            // paintImageXObject operations
-            hasImages = true;
-          }
-        } catch (pageError) {
-          // Skip problematic pages
-          console.warn(`Failed to analyze page ${i}:`, pageError);
         }
-      }
 
-      // Scale estimated text length to full document
-      if (estimatedTextLength > 0 && pageCount > pagesToSample) {
-        estimatedTextLength = Math.round(
-          (estimatedTextLength / pagesToSample) * pageCount,
-        );
-      }
+        // Scale estimated text length to full document
+        if (estimatedTextLength > 0 && pageCount > pagesToSample) {
+          estimatedTextLength = Math.round(
+            (estimatedTextLength / pagesToSample) * pageCount,
+          );
+        }
 
-      // Determine processing strategy
-      let recommendedStrategy: 'text' | 'ocr' | 'hybrid';
-      let ocrRequired = false;
+        // Determine processing strategy
+        let recommendedStrategy: 'text' | 'ocr' | 'hybrid';
+        let ocrRequired = false;
 
-      if (hasEmbeddedText) {
-        if (hasImages && estimatedTextLength < 500) {
-          // Has embedded text but very little - might need OCR for images
-          recommendedStrategy = 'hybrid';
-          ocrRequired = false;
+        if (hasEmbeddedText) {
+          if (hasImages && estimatedTextLength < 500) {
+            // Has embedded text but very little - might need OCR for images
+            recommendedStrategy = 'hybrid';
+            ocrRequired = false;
+          } else {
+            // Sufficient embedded text
+            recommendedStrategy = 'text';
+            ocrRequired = false;
+          }
         } else {
-          // Sufficient embedded text
-          recommendedStrategy = 'text';
-          ocrRequired = false;
+          // No embedded text found - likely image-based PDF
+          recommendedStrategy = 'ocr';
+          ocrRequired = true;
         }
-      } else {
-        // No embedded text found - likely image-based PDF
-        recommendedStrategy = 'ocr';
-        ocrRequired = true;
-      }
 
-      // Estimate processing times
-      const estimatedProcessingTime = {
-        textExtraction: hasEmbeddedText
-          ? ((estimatedTextLength > 50000 ? 'medium' : 'fast') as
-              | 'fast'
-              | 'medium'
-              | 'slow')
-          : ('fast' as 'fast' | 'medium' | 'slow'),
-        ocrProcessing:
-          hasImages || ocrRequired
-            ? ((pageCount > 10 ? 'slow' : pageCount > 3 ? 'medium' : 'fast') as
+        // Estimate processing times
+        const estimatedProcessingTime = {
+          textExtraction: hasEmbeddedText
+            ? ((estimatedTextLength > 50000 ? 'medium' : 'fast') as
                 | 'fast'
                 | 'medium'
                 | 'slow')
-            : undefined,
-      };
+            : ('fast' as 'fast' | 'medium' | 'slow'),
+          ocrProcessing:
+            hasImages || ocrRequired
+              ? ((pageCount > 10
+                  ? 'slow'
+                  : pageCount > 3
+                    ? 'medium'
+                    : 'fast') as 'fast' | 'medium' | 'slow')
+              : undefined,
+        };
 
-      return {
-        pageCount,
-        fileSize: buffer.length,
-        version: getMetadataInfoValue(metadata?.info, 'PDFFormatVersion'),
-        encrypted: getMetadataInfoValue(metadata?.info, 'Encrypted') === 'Yes',
-        hasEmbeddedText,
-        hasImages,
-        estimatedTextLength:
-          estimatedTextLength > 0 ? estimatedTextLength : undefined,
-        recommendedStrategy,
-        ocrRequired,
-        estimatedProcessingTime,
-        title: getMetadataInfoValue(metadata?.info, 'Title'),
-        author: getMetadataInfoValue(metadata?.info, 'Author'),
-        creationDate: getMetadataInfoDate(metadata?.info, 'CreationDate'),
-        creator: getMetadataInfoValue(metadata?.info, 'Creator'),
-        producer: getMetadataInfoValue(metadata?.info, 'Producer'),
-      };
+        return {
+          pageCount,
+          fileSize: buffer.length,
+          version: getMetadataInfoValue(metadata?.info, 'PDFFormatVersion'),
+          encrypted:
+            getMetadataInfoValue(metadata?.info, 'Encrypted') === 'Yes',
+          hasEmbeddedText,
+          hasImages,
+          estimatedTextLength:
+            estimatedTextLength > 0 ? estimatedTextLength : undefined,
+          recommendedStrategy,
+          ocrRequired,
+          estimatedProcessingTime,
+          title: getMetadataInfoValue(metadata?.info, 'Title'),
+          author: getMetadataInfoValue(metadata?.info, 'Author'),
+          creationDate: getMetadataInfoDate(metadata?.info, 'CreationDate'),
+          creator: getMetadataInfoValue(metadata?.info, 'Creator'),
+          producer: getMetadataInfoValue(metadata?.info, 'Producer'),
+        };
+      } finally {
+        await this.closePDFDocument(pdf);
+      }
     } catch (error) {
       console.error('unpdf getInfo failed:', error);
 

--- a/src/node/unpdf.ts
+++ b/src/node/unpdf.ts
@@ -46,6 +46,11 @@ type UnpdfExtractedImage = {
 type TextMarkedContent = { type: string; id: string };
 type NodeRenderableContext = NapiCanvasRenderingContext2D | SKRSContext2D;
 type PDFMetadataInfo = Record<string, unknown>;
+type PdfjsDocumentOptions = Pick<DocumentInitParameters, 'useWorkerFetch'> &
+  Partial<Pick<DocumentInitParameters, 'standardFontDataUrl' | 'wasmUrl'>>;
+type LoadPdfDocumentOptions = {
+  includeOptionalAssets?: boolean;
+};
 
 function readTextItem(item: TextItem | TextMarkedContent): string {
   return 'str' in item ? item.str : '';
@@ -93,10 +98,7 @@ export class UnpdfProvider extends BasePDFReader {
   private unpdfLoadPromise: Promise<UnpdfModule> | null = null;
   private configuredPdfjsWorkerSrc: string | null = null;
   private hasConfiguredUnpdfPdfjsModule = false;
-  private pdfjsDocumentOptions: Pick<
-    DocumentInitParameters,
-    'standardFontDataUrl' | 'useWorkerFetch' | 'wasmUrl'
-  > | null = null;
+  private pdfjsRenderDocumentOptions: PdfjsDocumentOptions | null = null;
 
   private rgbaToRgbBuffer(data: Uint8ClampedArray): Buffer {
     const rgbData = Buffer.alloc((data.length / 4) * 3);
@@ -149,8 +151,6 @@ export class UnpdfProvider extends BasePDFReader {
       );
       this.hasConfiguredUnpdfPdfjsModule = true;
     }
-
-    await this.ensurePdfjsWorkerConfigured();
   }
 
   private formatPdfjsAssetDirectory(path: string): string {
@@ -158,26 +158,45 @@ export class UnpdfProvider extends BasePDFReader {
     return normalized.endsWith('/') ? normalized : `${normalized}/`;
   }
 
-  private getPdfjsDocumentOptions(): Pick<
-    DocumentInitParameters,
-    'standardFontDataUrl' | 'useWorkerFetch' | 'wasmUrl'
-  > {
-    if (!this.pdfjsDocumentOptions) {
-      const standardFontDataUrl = this.formatPdfjsAssetDirectory(
-        dirname(require.resolve('pdfjs-dist/standard_fonts/FoxitSymbol.pfb')),
+  private resolveOptionalPdfjsAssetDirectory(
+    specifier: string,
+  ): string | undefined {
+    try {
+      return this.formatPdfjsAssetDirectory(
+        dirname(require.resolve(specifier)),
       );
-      const wasmUrl = this.formatPdfjsAssetDirectory(
-        dirname(require.resolve('pdfjs-dist/wasm/openjpeg.wasm')),
-      );
+    } catch {
+      return undefined;
+    }
+  }
 
-      this.pdfjsDocumentOptions = {
-        standardFontDataUrl,
+  private getPdfjsDocumentOptions(
+    includeOptionalAssets = false,
+  ): PdfjsDocumentOptions {
+    if (!includeOptionalAssets) {
+      return {
         useWorkerFetch: false,
-        wasmUrl,
       };
     }
 
-    return this.pdfjsDocumentOptions;
+    if (!this.pdfjsRenderDocumentOptions) {
+      // These assets are optional package extras in some deployments, so keep
+      // text/metadata flows working even when bundlers trim rendering assets.
+      const standardFontDataUrl = this.resolveOptionalPdfjsAssetDirectory(
+        'pdfjs-dist/standard_fonts/FoxitSymbol.pfb',
+      );
+      const wasmUrl = this.resolveOptionalPdfjsAssetDirectory(
+        'pdfjs-dist/wasm/openjpeg.wasm',
+      );
+
+      this.pdfjsRenderDocumentOptions = {
+        useWorkerFetch: false,
+        ...(standardFontDataUrl ? { standardFontDataUrl } : {}),
+        ...(wasmUrl ? { wasmUrl } : {}),
+      };
+    }
+
+    return this.pdfjsRenderDocumentOptions;
   }
 
   private async ensurePdfjsWorkerConfigured() {
@@ -406,7 +425,12 @@ export class UnpdfProvider extends BasePDFReader {
   private async loadPDFDocument(
     unpdf: UnpdfModule,
     source: PDFSource,
+    options?: LoadPdfDocumentOptions,
   ): Promise<UnpdfDocumentProxy> {
+    if (options?.includeOptionalAssets) {
+      await this.ensurePdfjsWorkerConfigured();
+    }
+
     const buffer = await this.normalizeSource(source);
 
     if (!this.validatePDFData(buffer)) {
@@ -416,7 +440,10 @@ export class UnpdfProvider extends BasePDFReader {
     // Clone in-memory sources so PDF.js worker transfer does not detach caller-owned buffers.
     const documentData =
       typeof source === 'string' ? buffer : new Uint8Array(buffer);
-    return unpdf.getDocumentProxy(documentData, this.getPdfjsDocumentOptions());
+    return unpdf.getDocumentProxy(
+      documentData,
+      this.getPdfjsDocumentOptions(options?.includeOptionalAssets),
+    );
   }
 
   private async closePDFDocument(pdf: UnpdfDocumentProxy): Promise<void> {
@@ -444,6 +471,24 @@ export class UnpdfProvider extends BasePDFReader {
     } finally {
       await this.closePDFDocument(pdf);
     }
+  }
+
+  private async getSourceFileSize(
+    source: PDFSource,
+  ): Promise<number | undefined> {
+    if (typeof source === 'string') {
+      try {
+        return (await fs.stat(source)).size;
+      } catch {
+        return undefined;
+      }
+    }
+
+    if (source instanceof ArrayBuffer || source instanceof Uint8Array) {
+      return source.byteLength;
+    }
+
+    return undefined;
   }
 
   private convertExtractedImage(
@@ -496,7 +541,9 @@ export class UnpdfProvider extends BasePDFReader {
     source: PDFSource,
     pages: number[],
   ): Promise<PDFImage[]> {
-    const pdf = await this.loadPDFDocument(unpdf, source);
+    const pdf = await this.loadPDFDocument(unpdf, source, {
+      includeOptionalAssets: true,
+    });
     const batchImages: PDFImage[] = [];
 
     try {
@@ -613,6 +660,7 @@ export class UnpdfProvider extends BasePDFReader {
 
       const document = await pdfjs.getDocument({
         data: buffer,
+        ...this.getPdfjsDocumentOptions(true),
       }).promise;
 
       try {
@@ -725,13 +773,8 @@ export class UnpdfProvider extends BasePDFReader {
   async getInfo(source: PDFSource): Promise<PDFInfo> {
     try {
       const unpdf = await this.loadUnpdf();
-      const buffer = await this.normalizeSource(source);
-
-      if (!this.validatePDFData(buffer)) {
-        throw new Error('Invalid PDF data');
-      }
-
-      const pdf = await this.loadPDFDocument(unpdf, buffer);
+      const pdf = await this.loadPDFDocument(unpdf, source);
+      const fileSize = await this.getSourceFileSize(source);
 
       try {
         const metadata = await pdf.getMetadata();
@@ -819,7 +862,7 @@ export class UnpdfProvider extends BasePDFReader {
 
         return {
           pageCount,
-          fileSize: buffer.length,
+          fileSize,
           version: getMetadataInfoValue(metadata?.info, 'PDFFormatVersion'),
           encrypted:
             getMetadataInfoValue(metadata?.info, 'Encrypted') === 'Yes',


### PR DESCRIPTION
## Summary

This fixes the remaining Node-side asset loading gap behind issue #67.

`unpdf` image extraction in Node was still vulnerable to missing PDF.js assets during document loading, which could surface as standard font warnings and JPEG2000/OpenJPEG decode failures during `extractImages()` runs.

## Root Cause

In Node, the `unpdf` provider was still relying on default document loading behavior without explicitly configuring a Node-friendly PDF.js runtime and asset paths.

That left standard font and wasm asset resolution too implicit for the large-document image extraction path, which is exactly where issue #67 was still reproducing.

## What Changed

- configure `unpdf` to use the official `pdfjs-dist/legacy` runtime in Node
- resolve `standardFontDataUrl` and `wasmUrl` from installed `pdfjs-dist` asset directories
- disable worker fetch for those document assets so Node uses filesystem-backed loading
- pass the document options through every `getDocumentProxy(...)` path used by the provider
- add regression coverage for runtime selection and Node asset-path behavior during image extraction
- centralize PDF document cleanup for the affected paths

## Impact

Node `extractImages()` is now much more reliable for PDFs that depend on standard fonts or OpenJPEG/JPEG2000 assets, especially large batched extractions like the issue #67 repro document.

Fixes #67.

## Validation

- `pnpm test`
- real repro PDF from issue #67 (`20260224_RCM_Agenda.pdf`)
  - 53 batches
  - 634 extracted images
  - 0 `Unable to load font data` warnings
  - 0 `OpenJPEG failed to initialize` warnings

## Notes

- `pnpm lint` still reports an unrelated pre-existing formatting issue in `package.json` that is not part of this change.
