### PR TITLE
fix(pdf): offload large text extraction

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,11 +15,7 @@
       "pdfjs-dist": "5.4.296"
     }
   },
-  "files": [
-    "dist",
-    "README.md",
-    "LICENSE"
-  ],
+  "files": ["dist", "README.md", "LICENSE"],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com",
     "access": "public"

--- a/src/node/child-extraction.test.ts
+++ b/src/node/child-extraction.test.ts
@@ -1,5 +1,63 @@
-import { describe, expect, it } from 'vitest';
-import { appendToDiagnosticTail } from './child-extraction';
+import { EventEmitter } from 'node:events';
+import * as fsPromises from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  appendToDiagnosticTail,
+  extractTextInChildProcess,
+} from './child-extraction';
+
+const spawnMock = vi.hoisted(() => vi.fn());
+
+vi.mock('node:child_process', () => ({
+  spawn: spawnMock,
+}));
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+
+  return {
+    ...actual,
+    access: vi.fn(async () => undefined),
+    rm: vi.fn(actual.rm),
+    writeFile: vi.fn(actual.writeFile),
+  };
+});
+
+type FakeChildProcess = EventEmitter & {
+  stdin: EventEmitter & { end: ReturnType<typeof vi.fn> };
+  stdout: EventEmitter & { setEncoding: ReturnType<typeof vi.fn> };
+  stderr: EventEmitter & { setEncoding: ReturnType<typeof vi.fn> };
+  kill: ReturnType<typeof vi.fn>;
+  stdinPayload?: string;
+};
+
+function createFakeChildProcess(): FakeChildProcess {
+  const child = new EventEmitter() as FakeChildProcess;
+
+  child.stdin = new EventEmitter() as FakeChildProcess['stdin'];
+  child.stdout = new EventEmitter() as FakeChildProcess['stdout'];
+  child.stderr = new EventEmitter() as FakeChildProcess['stderr'];
+  child.kill = vi.fn();
+  child.stdin.end = vi.fn((payload: string) => {
+    child.stdinPayload = payload;
+  });
+  child.stdout.setEncoding = vi.fn();
+  child.stderr.setEncoding = vi.fn();
+
+  return child;
+}
+
+async function expectTempDirRemoved(path: string): Promise<void> {
+  const actualFs =
+    await vi.importActual<typeof import('node:fs/promises')>(
+      'node:fs/promises',
+    );
+
+  await expect(actualFs.stat(dirname(path))).rejects.toMatchObject({
+    code: 'ENOENT',
+  });
+}
 
 describe('child extraction diagnostics', () => {
   it('keeps only the diagnostic tail when child stderr is noisy', () => {
@@ -7,5 +65,122 @@ describe('child extraction diagnostics', () => {
     stderr = appendToDiagnosticTail(stderr, 'abcdef', 12);
 
     expect(stderr).toBe('456789abcdef');
+  });
+});
+
+describe('extractTextInChildProcess', () => {
+  beforeEach(() => {
+    vi.mocked(fsPromises.access).mockResolvedValue(undefined);
+    vi.mocked(fsPromises.rm).mockImplementation(async (...args) => {
+      const actualFs =
+        await vi.importActual<typeof import('node:fs/promises')>(
+          'node:fs/promises',
+        );
+      return actualFs.rm(...args);
+    });
+    vi.mocked(fsPromises.writeFile).mockImplementation(async (...args) => {
+      const actualFs =
+        await vi.importActual<typeof import('node:fs/promises')>(
+          'node:fs/promises',
+        );
+      return actualFs.writeFile(...args);
+    });
+    spawnMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns worker text and removes the temp source file on success', async () => {
+    const child = createFakeChildProcess();
+    child.stdin.end.mockImplementation((payload: string) => {
+      child.stdinPayload = payload;
+      queueMicrotask(() => {
+        child.stdout.emit(
+          'data',
+          JSON.stringify({ ok: true, text: 'worker text' }),
+        );
+        child.emit('close', 0, null);
+      });
+    });
+    spawnMock.mockReturnValue(child);
+
+    await expect(
+      extractTextInChildProcess(
+        new Uint8Array([37, 80, 68, 70]),
+        { mergePages: true },
+        { ocrProvider: 'auto' },
+      ),
+    ).resolves.toBe('worker text');
+
+    const payload = JSON.parse(child.stdinPayload || '{}');
+    expect(payload.source.kind).toBe('temp-file');
+    expect(payload.options).toMatchObject({ mergePages: true });
+    expect(payload.readerOptions).toMatchObject({ ocrProvider: 'auto' });
+    await expectTempDirRemoved(payload.source.path);
+  });
+
+  it('rejects invalid worker JSON and removes the temp source file', async () => {
+    const child = createFakeChildProcess();
+    child.stdin.end.mockImplementation((payload: string) => {
+      child.stdinPayload = payload;
+      queueMicrotask(() => {
+        child.stderr.emit('data', 'worker warning');
+        child.stdout.emit('data', 'not json');
+        child.emit('close', 0, null);
+      });
+    });
+    spawnMock.mockReturnValue(child);
+
+    await expect(
+      extractTextInChildProcess(new Uint8Array([1, 2, 3]), undefined, {}),
+    ).rejects.toThrow('PDF child extraction returned invalid JSON');
+
+    const payload = JSON.parse(child.stdinPayload || '{}');
+    await expectTempDirRemoved(payload.source.path);
+  });
+
+  it('rejects child stdio errors instead of hanging', async () => {
+    const child = createFakeChildProcess();
+    child.stdin.end.mockImplementation(() => {
+      queueMicrotask(() => {
+        child.stdout.emit('error', new Error('stdout broke'));
+      });
+    });
+    spawnMock.mockReturnValue(child);
+
+    await expect(
+      extractTextInChildProcess('/tmp/source.pdf', undefined, {}),
+    ).rejects.toThrow('stdout broke');
+  });
+
+  it('kills the child on timeout and removes the temp source file', async () => {
+    const child = createFakeChildProcess();
+    spawnMock.mockReturnValue(child);
+
+    await expect(
+      extractTextInChildProcess(new Uint8Array([1, 2, 3]), undefined, {}, 1),
+    ).rejects.toThrow('PDF child extraction timed out after 1ms');
+
+    expect(child.kill).toHaveBeenCalledWith('SIGKILL');
+    const payload = JSON.parse(child.stdinPayload || '{}');
+    await expectTempDirRemoved(payload.source.path);
+  });
+
+  it('removes the temp directory if writing a buffer source fails', async () => {
+    vi.mocked(fsPromises.writeFile).mockRejectedValueOnce(
+      new Error('disk full'),
+    );
+
+    await expect(
+      extractTextInChildProcess(new Uint8Array([1, 2, 3]), undefined, {}),
+    ).rejects.toThrow('disk full');
+
+    expect(fsPromises.rm).toHaveBeenCalledWith(
+      expect.stringContaining('happyvertical-pdf-child-'),
+      { recursive: true, force: true },
+    );
+    expect(spawnMock).not.toHaveBeenCalled();
   });
 });

--- a/src/node/child-extraction.test.ts
+++ b/src/node/child-extraction.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { appendToDiagnosticTail } from './child-extraction';
+
+describe('child extraction diagnostics', () => {
+  it('keeps only the diagnostic tail when child stderr is noisy', () => {
+    let stderr = appendToDiagnosticTail('', '0123456789', 12);
+    stderr = appendToDiagnosticTail(stderr, 'abcdef', 12);
+
+    expect(stderr).toBe('456789abcdef');
+  });
+});

--- a/src/node/child-extraction.ts
+++ b/src/node/child-extraction.ts
@@ -17,6 +17,7 @@ const CHILD_WORKER_PATHS = [
   new URL(/* @vite-ignore */ '../node/extract-worker.js', import.meta.url),
   new URL(/* @vite-ignore */ './node/extract-worker.js', import.meta.url),
 ];
+const MAX_CHILD_STDERR_CHARS = 64 * 1024;
 
 type WorkerSourcePayload =
   | { kind: 'path'; path: string }
@@ -135,6 +136,24 @@ function toError(error: unknown): Error {
   return error instanceof Error ? error : new Error(String(error));
 }
 
+export function appendToDiagnosticTail(
+  current: string,
+  chunk: string,
+  limit = MAX_CHILD_STDERR_CHARS,
+): string {
+  const combined = current + chunk;
+  return combined.length > limit ? combined.slice(-limit) : combined;
+}
+
+function formatChildStderr(stderr: string, truncated: boolean): string {
+  const trimmed = stderr.trim();
+  if (!trimmed) {
+    return '';
+  }
+
+  return truncated ? `[stderr truncated]\n${trimmed}` : trimmed;
+}
+
 export async function extractTextInChildProcess(
   source: PDFSource,
   options: ExtractTextOptions | undefined,
@@ -162,6 +181,7 @@ export async function extractTextInChildProcess(
 
       let stdout = '';
       let stderr = '';
+      let stderrTruncated = false;
       let settled = false;
       let timeout: NodeJS.Timeout | undefined;
 
@@ -191,7 +211,11 @@ export async function extractTextInChildProcess(
         stdout += chunk;
       });
       child.stderr.on('data', (chunk) => {
-        stderr += chunk;
+        const text = String(chunk);
+        stderrTruncated =
+          stderrTruncated ||
+          stderr.length + text.length > MAX_CHILD_STDERR_CHARS;
+        stderr = appendToDiagnosticTail(stderr, text);
       });
       child.on('error', (error) => {
         finish(() => reject(error));
@@ -208,10 +232,11 @@ export async function extractTextInChildProcess(
       child.on('close', (code, signal) => {
         finish(() => {
           if (code !== 0) {
+            const stderrMessage = formatChildStderr(stderr, stderrTruncated);
             reject(
               new PDFChildExtractionError(
                 `PDF child extraction exited with ${signal ?? code}${
-                  stderr.trim() ? `: ${stderr.trim()}` : ''
+                  stderrMessage ? `: ${stderrMessage}` : ''
                 }`,
               ),
             );
@@ -222,11 +247,12 @@ export async function extractTextInChildProcess(
           try {
             result = JSON.parse(stdout) as WorkerResult;
           } catch (error) {
+            const stderrMessage = formatChildStderr(stderr, stderrTruncated);
             reject(
               new PDFChildExtractionError(
                 `PDF child extraction returned invalid JSON: ${
                   error instanceof Error ? error.message : String(error)
-                }${stderr.trim() ? `; stderr: ${stderr.trim()}` : ''}`,
+                }${stderrMessage ? `; stderr: ${stderrMessage}` : ''}`,
               ),
             );
             return;

--- a/src/node/child-extraction.ts
+++ b/src/node/child-extraction.ts
@@ -81,7 +81,13 @@ async function prepareSourcePayload(source: PDFSource): Promise<{
     source instanceof ArrayBuffer
       ? Buffer.from(source)
       : Buffer.from(source.buffer, source.byteOffset, source.byteLength);
-  await writeFile(tempFile, data);
+
+  try {
+    await writeFile(tempFile, data);
+  } catch (error) {
+    await rm(tempDir, { recursive: true, force: true });
+    throw error;
+  }
 
   return {
     payload: { kind: 'temp-file', path: tempFile },

--- a/src/node/child-extraction.ts
+++ b/src/node/child-extraction.ts
@@ -1,0 +1,253 @@
+import { spawn } from 'node:child_process';
+import { access, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { OCROptions } from '@happyvertical/ocr';
+import type { ExtractTextOptions, PDFSource } from '../shared/types';
+import {
+  PDFBatchExtractionError,
+  PDFError,
+  PDFFileSizeError,
+} from '../shared/types';
+
+export const DISABLE_CHILD_EXTRACTION_ENV = 'HAVE_PDF_DISABLE_CHILD_EXTRACTION';
+
+const CHILD_WORKER_PATHS = [
+  new URL(/* @vite-ignore */ '../node/extract-worker.js', import.meta.url),
+  new URL(/* @vite-ignore */ './node/extract-worker.js', import.meta.url),
+];
+
+type WorkerSourcePayload =
+  | { kind: 'path'; path: string }
+  | { kind: 'temp-file'; path: string };
+
+interface WorkerReaderOptions {
+  ocrProvider?: string;
+  defaultOCROptions?: OCROptions;
+  maxFileSize?: number;
+}
+
+interface WorkerPayload {
+  source: WorkerSourcePayload;
+  options?: ExtractTextOptions;
+  readerOptions: WorkerReaderOptions;
+}
+
+type WorkerErrorPayload = {
+  name?: string;
+  message?: string;
+  code?: string;
+  pages?: number[];
+  actualSizeBytes?: number;
+  maxSizeBytes?: number;
+};
+
+type WorkerResult =
+  | { ok: true; text: string | null }
+  | { ok: false; error: WorkerErrorPayload };
+
+export class PDFChildExtractionError extends PDFError {
+  constructor(message: string) {
+    super(message, 'ECHILD');
+    this.name = 'PDFChildExtractionError';
+  }
+}
+
+function shouldDisableChildExtraction(): boolean {
+  const value = process.env[DISABLE_CHILD_EXTRACTION_ENV]?.toLowerCase();
+  return value === '1' || value === 'true' || value === 'yes';
+}
+
+export function canUseChildExtraction(): boolean {
+  return !shouldDisableChildExtraction();
+}
+
+async function prepareSourcePayload(source: PDFSource): Promise<{
+  payload: WorkerSourcePayload;
+  cleanup: () => Promise<void>;
+}> {
+  if (typeof source === 'string') {
+    return {
+      payload: { kind: 'path', path: source },
+      cleanup: async () => {},
+    };
+  }
+
+  const tempDir = await mkdtemp(join(tmpdir(), 'happyvertical-pdf-child-'));
+  const tempFile = join(tempDir, 'source.pdf');
+  const data =
+    source instanceof ArrayBuffer
+      ? Buffer.from(source)
+      : Buffer.from(source.buffer, source.byteOffset, source.byteLength);
+  await writeFile(tempFile, data);
+
+  return {
+    payload: { kind: 'temp-file', path: tempFile },
+    cleanup: async () => {
+      await rm(tempDir, { recursive: true, force: true });
+    },
+  };
+}
+
+async function resolveChildWorkerPath(): Promise<string> {
+  for (const workerUrl of CHILD_WORKER_PATHS) {
+    const workerPath = fileURLToPath(workerUrl);
+    try {
+      await access(workerPath);
+      return workerPath;
+    } catch {
+      // Try the next build layout candidate.
+    }
+  }
+
+  throw new PDFChildExtractionError(
+    `Unable to locate PDF child extraction worker. Checked: ${CHILD_WORKER_PATHS.map((workerUrl) => fileURLToPath(workerUrl)).join(', ')}`,
+  );
+}
+
+function reviveWorkerError(error: WorkerErrorPayload): Error {
+  if (error.name === 'PDFBatchExtractionError' && Array.isArray(error.pages)) {
+    return new PDFBatchExtractionError(error.pages, error.message);
+  }
+
+  if (
+    error.name === 'PDFFileSizeError' &&
+    typeof error.actualSizeBytes === 'number' &&
+    typeof error.maxSizeBytes === 'number'
+  ) {
+    return new PDFFileSizeError(error.actualSizeBytes, error.maxSizeBytes);
+  }
+
+  if (error.name === 'PDFError') {
+    return new PDFError(
+      error.message || 'PDF child extraction failed',
+      error.code,
+    );
+  }
+
+  const revived = new Error(error.message || 'PDF child extraction failed');
+  revived.name = error.name || 'PDFChildExtractionError';
+  return revived;
+}
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+export async function extractTextInChildProcess(
+  source: PDFSource,
+  options: ExtractTextOptions | undefined,
+  readerOptions: WorkerReaderOptions,
+  timeoutMs?: number,
+): Promise<string | null> {
+  const { payload, cleanup } = await prepareSourcePayload(source);
+
+  try {
+    const workerPath = await resolveChildWorkerPath();
+    const workerPayload: WorkerPayload = {
+      source: payload,
+      options,
+      readerOptions,
+    };
+
+    return await new Promise<string | null>((resolve, reject) => {
+      const child = spawn(process.execPath, [workerPath], {
+        env: {
+          ...process.env,
+          [DISABLE_CHILD_EXTRACTION_ENV]: '1',
+        },
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+
+      let stdout = '';
+      let stderr = '';
+      let settled = false;
+      let timeout: NodeJS.Timeout | undefined;
+
+      const finish = (callback: () => void) => {
+        if (settled) return;
+        settled = true;
+        if (timeout) clearTimeout(timeout);
+        callback();
+      };
+
+      if (timeoutMs && timeoutMs > 0) {
+        timeout = setTimeout(() => {
+          child.kill('SIGKILL');
+          finish(() =>
+            reject(
+              new PDFChildExtractionError(
+                `PDF child extraction timed out after ${timeoutMs}ms`,
+              ),
+            ),
+          );
+        }, timeoutMs);
+      }
+
+      child.stdout.setEncoding('utf8');
+      child.stderr.setEncoding('utf8');
+      child.stdout.on('data', (chunk) => {
+        stdout += chunk;
+      });
+      child.stderr.on('data', (chunk) => {
+        stderr += chunk;
+      });
+      child.on('error', (error) => {
+        finish(() => reject(error));
+      });
+      child.stdin.on('error', (error) => {
+        finish(() => reject(error));
+      });
+      child.stdout.on('error', (error) => {
+        finish(() => reject(error));
+      });
+      child.stderr.on('error', (error) => {
+        finish(() => reject(error));
+      });
+      child.on('close', (code, signal) => {
+        finish(() => {
+          if (code !== 0) {
+            reject(
+              new PDFChildExtractionError(
+                `PDF child extraction exited with ${signal ?? code}${
+                  stderr.trim() ? `: ${stderr.trim()}` : ''
+                }`,
+              ),
+            );
+            return;
+          }
+
+          let result: WorkerResult;
+          try {
+            result = JSON.parse(stdout) as WorkerResult;
+          } catch (error) {
+            reject(
+              new PDFChildExtractionError(
+                `PDF child extraction returned invalid JSON: ${
+                  error instanceof Error ? error.message : String(error)
+                }${stderr.trim() ? `; stderr: ${stderr.trim()}` : ''}`,
+              ),
+            );
+            return;
+          }
+
+          if (result.ok) {
+            resolve(result.text);
+            return;
+          }
+
+          reject(reviveWorkerError(result.error));
+        });
+      });
+
+      try {
+        child.stdin.end(JSON.stringify(workerPayload));
+      } catch (error) {
+        finish(() => reject(toError(error)));
+      }
+    });
+  } finally {
+    await cleanup();
+  }
+}

--- a/src/node/combined.test.ts
+++ b/src/node/combined.test.ts
@@ -1,9 +1,24 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { PDFBatchExtractionError, PDFFileSizeError } from '../shared/types';
+import { DISABLE_CHILD_EXTRACTION_ENV } from './child-extraction';
 import { CombinedNodeProvider } from './combined';
 import { UnpdfProvider } from './unpdf';
 
 describe('CombinedNodeProvider', () => {
+  const originalChildExtractionEnv = process.env[DISABLE_CHILD_EXTRACTION_ENV];
+
+  beforeEach(() => {
+    process.env[DISABLE_CHILD_EXTRACTION_ENV] = '1';
+  });
+
+  afterEach(() => {
+    if (originalChildExtractionEnv === undefined) {
+      delete process.env[DISABLE_CHILD_EXTRACTION_ENV];
+    } else {
+      process.env[DISABLE_CHILD_EXTRACTION_ENV] = originalChildExtractionEnv;
+    }
+  });
+
   it('should report unavailable when unpdf dependencies are missing', async () => {
     const reader = new CombinedNodeProvider() as any;
 
@@ -409,6 +424,58 @@ describe('CombinedNodeProvider', () => {
       reader.extractText(new Uint8Array([1, 2, 3, 4, 5])),
     ).rejects.toBeInstanceOf(PDFFileSizeError);
     expect(reader.getInfo).not.toHaveBeenCalled();
+  });
+
+  it('offloads large extractions without blocking the parent heartbeat loop', async () => {
+    delete process.env[DISABLE_CHILD_EXTRACTION_ENV];
+
+    const reader = new CombinedNodeProvider() as any;
+    reader.getSourceByteLength = vi.fn().mockResolvedValue(25 * 1024 * 1024);
+    reader.getInfo = vi.fn();
+    reader.childExtractText = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(() => resolve('child text'), 20);
+        }),
+    );
+
+    let heartbeatTicks = 0;
+    const heartbeat = setInterval(() => {
+      heartbeatTicks += 1;
+    }, 1);
+
+    try {
+      await expect(reader.extractText('/tmp/large.pdf')).resolves.toBe(
+        'child text',
+      );
+    } finally {
+      clearInterval(heartbeat);
+    }
+
+    expect(heartbeatTicks).toBeGreaterThan(0);
+    expect(reader.childExtractText).toHaveBeenCalledWith(
+      '/tmp/large.pdf',
+      undefined,
+    );
+    expect(reader.getInfo).not.toHaveBeenCalled();
+  });
+
+  it('propagates child extraction failures instead of falling back to partial local work', async () => {
+    delete process.env[DISABLE_CHILD_EXTRACTION_ENV];
+
+    const reader = new CombinedNodeProvider() as any;
+    reader.getSourceByteLength = vi.fn().mockResolvedValue(25 * 1024 * 1024);
+    reader.childExtractText = vi
+      .fn()
+      .mockRejectedValue(new Error('child extraction failed'));
+    reader.unpdfProvider = {
+      extractText: vi.fn().mockResolvedValue('local text'),
+    };
+
+    await expect(reader.extractText('/tmp/large.pdf')).rejects.toThrow(
+      'child extraction failed',
+    );
+    expect(reader.unpdfProvider.extractText).not.toHaveBeenCalled();
   });
 
   it('skips expensive getInfo for small inputs without paging hints', async () => {

--- a/src/node/combined.ts
+++ b/src/node/combined.ts
@@ -389,12 +389,15 @@ export class CombinedNodeProvider extends BasePDFReader {
       return null;
     }
 
+    let usingChildExtraction = false;
+
     try {
       const sourceByteLength = await this.getSourceByteLength(source);
       await this.assertWithinConfiguredMaxFileSize(source, sourceByteLength);
 
       if (this.shouldUseChildExtraction(sourceByteLength)) {
-        return this.childExtractText(source, options);
+        usingChildExtraction = true;
+        return await this.childExtractText(source, options);
       }
 
       if (this.shouldInspectForBatching(sourceByteLength, options)) {
@@ -453,6 +456,10 @@ export class CombinedNodeProvider extends BasePDFReader {
         error instanceof PDFBatchExtractionError ||
         error instanceof PDFFileSizeError
       ) {
+        throw error;
+      }
+
+      if (usingChildExtraction) {
         throw error;
       }
 

--- a/src/node/combined.ts
+++ b/src/node/combined.ts
@@ -18,6 +18,10 @@ import type {
   PDFSource,
 } from '../shared/types';
 import { PDFBatchExtractionError, PDFFileSizeError } from '../shared/types';
+import {
+  canUseChildExtraction,
+  extractTextInChildProcess,
+} from './child-extraction';
 import { UnpdfProvider } from './unpdf';
 
 const LARGE_DOCUMENT_BATCH_BYTES = 20 * 1024 * 1024;
@@ -40,21 +44,26 @@ export class CombinedNodeProvider extends BasePDFReader {
   protected name = 'combined-node';
   private unpdfProvider: UnpdfProvider;
   private ocrFactory: ReturnType<typeof getOCR>;
+  private ocrProvider?: string;
   private defaultOCROptions?: OCROptions;
   private maxFileSize?: number;
+  private timeout?: number;
 
   constructor(
     options: {
       ocrProvider?: string;
       defaultOCROptions?: OCROptions;
       maxFileSize?: number;
+      timeout?: number;
     } = {},
   ) {
     super();
     this.unpdfProvider = new UnpdfProvider();
+    this.ocrProvider = options.ocrProvider;
     this.ocrFactory = getOCR({ provider: options.ocrProvider || 'auto' });
     this.defaultOCROptions = options.defaultOCROptions;
     this.maxFileSize = options.maxFileSize;
+    this.timeout = options.timeout;
   }
 
   private mergeOCROptions(options?: OCROptions): OCROptions | undefined {
@@ -133,6 +142,32 @@ export class CombinedNodeProvider extends BasePDFReader {
     }
 
     return Boolean(options?.pages && options.pages.length > OCR_BATCH_SIZE);
+  }
+
+  private shouldUseChildExtraction(
+    sourceByteLength: number | undefined,
+  ): boolean {
+    return Boolean(
+      canUseChildExtraction() &&
+        sourceByteLength &&
+        sourceByteLength >= LARGE_DOCUMENT_BATCH_BYTES,
+    );
+  }
+
+  private childExtractText(
+    source: PDFSource,
+    options?: ExtractTextOptions,
+  ): Promise<string | null> {
+    return extractTextInChildProcess(
+      source,
+      options,
+      {
+        ocrProvider: this.ocrProvider,
+        defaultOCROptions: this.defaultOCROptions,
+        maxFileSize: this.maxFileSize,
+      },
+      this.timeout,
+    );
   }
 
   private chunkPages(pages: number[], batchSize: number): number[][] {
@@ -357,6 +392,10 @@ export class CombinedNodeProvider extends BasePDFReader {
     try {
       const sourceByteLength = await this.getSourceByteLength(source);
       await this.assertWithinConfiguredMaxFileSize(source, sourceByteLength);
+
+      if (this.shouldUseChildExtraction(sourceByteLength)) {
+        return this.childExtractText(source, options);
+      }
 
       if (this.shouldInspectForBatching(sourceByteLength, options)) {
         const info = await this.getInfo(source);

--- a/src/node/extract-worker.ts
+++ b/src/node/extract-worker.ts
@@ -1,0 +1,93 @@
+import type { ExtractTextOptions } from '../shared/types';
+import { CombinedNodeProvider } from './combined';
+
+function writeLogToStderr(level: string, args: unknown[]): void {
+  const line = args
+    .map((arg) => {
+      if (arg instanceof Error) {
+        return `${arg.name}: ${arg.message}`;
+      }
+      if (typeof arg === 'string') {
+        return arg;
+      }
+      try {
+        return JSON.stringify(arg);
+      } catch {
+        return String(arg);
+      }
+    })
+    .join(' ');
+  process.stderr.write(`[${level}] ${line}\n`);
+}
+
+console.log = (...args: unknown[]) => writeLogToStderr('log', args);
+console.warn = (...args: unknown[]) => writeLogToStderr('warn', args);
+console.error = (...args: unknown[]) => writeLogToStderr('error', args);
+
+interface WorkerPayload {
+  source: { kind: 'path' | 'temp-file'; path: string };
+  options?: Record<string, unknown>;
+  readerOptions?: Record<string, unknown>;
+}
+
+type WorkerReaderOptions = ConstructorParameters<
+  typeof CombinedNodeProvider
+>[0];
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+function serializeError(error: unknown): Record<string, unknown> {
+  if (!(error instanceof Error)) {
+    return {
+      name: 'Error',
+      message: String(error),
+    };
+  }
+
+  const payload: Record<string, unknown> = {
+    name: error.name,
+    message: error.message,
+  };
+  const maybePdfError = error as Error & {
+    code?: string;
+    pages?: number[];
+    actualSizeBytes?: number;
+    maxSizeBytes?: number;
+  };
+
+  if (maybePdfError.code) payload.code = maybePdfError.code;
+  if (maybePdfError.pages) payload.pages = maybePdfError.pages;
+  if (maybePdfError.actualSizeBytes !== undefined) {
+    payload.actualSizeBytes = maybePdfError.actualSizeBytes;
+  }
+  if (maybePdfError.maxSizeBytes !== undefined) {
+    payload.maxSizeBytes = maybePdfError.maxSizeBytes;
+  }
+
+  return payload;
+}
+
+try {
+  const payload = JSON.parse(await readStdin()) as WorkerPayload;
+  const reader = new CombinedNodeProvider(
+    (payload.readerOptions ?? {}) as WorkerReaderOptions,
+  );
+  const text = await reader.extractText(
+    payload.source.path,
+    payload.options as ExtractTextOptions | undefined,
+  );
+  process.stdout.write(JSON.stringify({ ok: true, text }));
+} catch (error) {
+  process.stdout.write(
+    JSON.stringify({
+      ok: false,
+      error: serializeError(error),
+    }),
+  );
+}

--- a/src/shared/factory.ts
+++ b/src/shared/factory.ts
@@ -56,6 +56,7 @@ async function canUseCombinedNodeProvider(
       ocrProvider: options.ocrProvider,
       defaultOCROptions: options.defaultOCROptions,
       maxFileSize: options.maxFileSize,
+      timeout: options.timeout,
     });
     const deps = await reader.checkDependencies();
     return deps.available;
@@ -210,6 +211,7 @@ export async function getPDFReader(
         ocrProvider: readerOptions.ocrProvider as string | undefined,
         defaultOCROptions: readerOptions.defaultOCROptions,
         maxFileSize: readerOptions.maxFileSize,
+        timeout: readerOptions.timeout,
       });
     }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,9 +5,12 @@ import dts from 'vite-plugin-dts';
 export default defineConfig({
   build: {
     lib: {
-      entry: resolve(__dirname, 'src/index.ts'),
+      entry: {
+        index: resolve(__dirname, 'src/index.ts'),
+        'node/extract-worker': resolve(__dirname, 'src/node/extract-worker.ts'),
+      },
       formats: ['es'] as const,
-      fileName: () => 'index.js',
+      fileName: (_format, entryName) => `${entryName}.js`,
     },
     rollupOptions: {
       output: {


### PR DESCRIPTION
## Summary

Move large `CombinedNodeProvider.extractText()` work into an isolated child process so callers keep their Node event loop free for scheduler heartbeats while the existing large-document batching logic runs in the worker.

## What changed

- Added a packaged Node extraction worker and parent-side child-process bridge.
- Large sources now offload transparently from `extractText()` once they cross the existing large-document threshold.
- The worker disables nested child extraction, preserves caller OCR/max-size options, propagates structured PDF errors, and cleans temp source files for buffer inputs.
- Added tests for non-blocking parent heartbeat behavior and child extraction failure propagation.

## Local review notes

During local review I tightened two issues before opening this PR:

- Preserved caller-selected `ocrProvider` when extraction crosses into the child worker.
- Added stdin/stdout/stderr error handling around the child process so stream failures reject instead of becoming unhandled process errors.

## Verification

- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run src/node/combined.test.ts --testTimeout 120000`
- `pnpm lint`
- `pnpm build`
- `pnpm test`
- Built-package smoke test with a 22.6MB padded PDF fixture through `dist/index.js`, confirming the published worker path resolves and text extraction completes.