### PR TITLE
fix(pdf): harden OCR fallback and image extraction

### DIFF
--- a/.changeset/pdf-70-71-release.md
+++ b/.changeset/pdf-70-71-release.md
@@ -1,0 +1,5 @@
+---
+"@happyvertical/pdf": patch
+---
+
+Fail explicitly when OCR fallback cannot render or recognize text, and cap collected image extraction bytes so large PDFs use the existing batched `onBatch` path instead of retaining unbounded image buffers.

--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ await reader.extractImages('/path/to/large-document.pdf', {
 });
 ```
 
+Collected image extraction is protected by a bounded byte limit. For large or
+image-heavy PDFs, use `onBatch` with `collect: false` to persist or OCR each
+batch incrementally instead of returning every image buffer at once.
+
 ### OCR Processing
 
 ```typescript
@@ -184,6 +188,10 @@ try {
 } catch (error) {
   if (error.name === 'PDFDependencyError') {
     console.error('Missing dependencies:', error.message);
+  } else if (error.name === 'PDFOCRFallbackError') {
+    console.error('OCR fallback failed:', error.message);
+  } else if (error.name === 'PDFImageCollectionLimitError') {
+    console.error('Use batched image extraction:', error.message);
   } else if (error.name === 'PDFUnsupportedError') {
     console.error('Unsupported operation:', error.message);
   } else {

--- a/package.json
+++ b/package.json
@@ -15,11 +15,7 @@
       "pdfjs-dist": "5.4.296"
     }
   },
-  "files": [
-    "dist",
-    "README.md",
-    "LICENSE"
-  ],
+  "files": ["dist", "README.md", "LICENSE"],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com",
     "access": "public"

--- a/src/node/child-extraction.ts
+++ b/src/node/child-extraction.ts
@@ -9,6 +9,7 @@ import {
   PDFBatchExtractionError,
   PDFError,
   PDFFileSizeError,
+  PDFOCRFallbackError,
 } from '../shared/types';
 
 export const DISABLE_CHILD_EXTRACTION_ENV = 'HAVE_PDF_DISABLE_CHILD_EXTRACTION';
@@ -116,6 +117,13 @@ async function resolveChildWorkerPath(): Promise<string> {
 function reviveWorkerError(error: WorkerErrorPayload): Error {
   if (error.name === 'PDFBatchExtractionError' && Array.isArray(error.pages)) {
     return new PDFBatchExtractionError(error.pages, error.message);
+  }
+
+  if (error.name === 'PDFOCRFallbackError') {
+    return new PDFOCRFallbackError(
+      error.message || 'PDF OCR fallback failed',
+      error.pages,
+    );
   }
 
   if (

--- a/src/node/combined.test.ts
+++ b/src/node/combined.test.ts
@@ -393,24 +393,30 @@ describe('CombinedNodeProvider', () => {
     );
   });
 
-  it('returns null for invalid OCR fallback pages without rendering', async () => {
-    const reader = new CombinedNodeProvider() as any;
+  it.each([
+    { pages: [] as number[], label: 'empty' },
+    { pages: [99], label: 'out-of-range' },
+  ])(
+    'returns null for $label OCR fallback pages without rendering',
+    async ({ pages }) => {
+      const reader = new CombinedNodeProvider() as any;
 
-    reader.unpdfProvider = {
-      extractText: vi.fn().mockResolvedValue(''),
-      getInfo: vi.fn().mockResolvedValue({ pageCount: 2 }),
-      renderPages: vi.fn(),
-    };
-    reader.ocrFactory = {
-      performOCR: vi.fn(),
-    };
+      reader.unpdfProvider = {
+        extractText: vi.fn().mockResolvedValue(''),
+        getInfo: vi.fn().mockResolvedValue({ pageCount: 2 }),
+        renderPages: vi.fn(),
+      };
+      reader.ocrFactory = {
+        performOCR: vi.fn(),
+      };
 
-    await expect(
-      reader.extractText('/tmp/scanned.pdf', { pages: [99] }),
-    ).resolves.toBeNull();
-    expect(reader.unpdfProvider.renderPages).not.toHaveBeenCalled();
-    expect(reader.ocrFactory.performOCR).not.toHaveBeenCalled();
-  });
+      await expect(
+        reader.extractText('/tmp/scanned.pdf', { pages }),
+      ).resolves.toBeNull();
+      expect(reader.unpdfProvider.renderPages).not.toHaveBeenCalled();
+      expect(reader.ocrFactory.performOCR).not.toHaveBeenCalled();
+    },
+  );
 
   it('surfaces OCR fallback rendering failures instead of returning null', async () => {
     const reader = new CombinedNodeProvider() as any;
@@ -974,6 +980,18 @@ describe('UnpdfProvider', () => {
 
     await expect(reader.extractImages(new Uint8Array())).resolves.toEqual([]);
     expect(reader.loadUnpdf).not.toHaveBeenCalled();
+  });
+
+  it('does not reject non-empty ArrayBuffer render sources as invalid input', async () => {
+    const reader = new UnpdfProvider() as any;
+    reader.ensurePdfjsWorkerConfigured = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      reader.renderPages(new Uint8Array([1, 2, 3, 4, 5]).buffer, {
+        throwOnError: true,
+      }),
+    ).rejects.toBeInstanceOf(PDFOCRFallbackError);
+    expect(reader.ensurePdfjsWorkerConfigured).toHaveBeenCalledOnce();
   });
 
   it('preserves page and image order across collected image batches', async () => {

--- a/src/node/combined.test.ts
+++ b/src/node/combined.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { PDFBatchExtractionError, PDFFileSizeError } from '../shared/types';
+import {
+  PDFBatchExtractionError,
+  PDFFileSizeError,
+  PDFImageCollectionLimitError,
+  PDFOCRFallbackError,
+} from '../shared/types';
 import { DISABLE_CHILD_EXTRACTION_ENV } from './child-extraction';
 import { CombinedNodeProvider } from './combined';
 import { UnpdfProvider } from './unpdf';
@@ -219,6 +224,7 @@ describe('CombinedNodeProvider', () => {
 
     reader.unpdfProvider = {
       extractText: vi.fn().mockResolvedValue(''),
+      getInfo: vi.fn().mockResolvedValue({ pageCount: 1 }),
       renderPages: vi.fn().mockResolvedValue([
         {
           data: Buffer.from([1]),
@@ -247,6 +253,70 @@ describe('CombinedNodeProvider', () => {
         confidenceThreshold: 72,
       }),
     );
+  });
+
+  it('throws an explicit OCR fallback error when rendered OCR returns no text', async () => {
+    const reader = new CombinedNodeProvider() as any;
+
+    reader.unpdfProvider = {
+      extractText: vi.fn().mockResolvedValue(''),
+      getInfo: vi.fn().mockResolvedValue({ pageCount: 1 }),
+      renderPages: vi.fn().mockResolvedValue([
+        {
+          data: Buffer.from([1]),
+          format: 'rgb',
+          width: 10,
+          height: 10,
+          channels: 3,
+          pageNumber: 1,
+        },
+      ]),
+    };
+    reader.ocrFactory = {
+      performOCR: vi.fn().mockResolvedValue({
+        text: '',
+        confidence: 0,
+        detections: [],
+        metadata: {
+          provider: 'onnx',
+        },
+      }),
+    };
+
+    await expect(reader.extractText('/tmp/scanned.pdf')).rejects.toBeInstanceOf(
+      PDFOCRFallbackError,
+    );
+    await expect(reader.extractText('/tmp/scanned.pdf')).rejects.toThrow(
+      'OCR fallback produced no text for all pages. Provider: onnx. Confidence: 0.0. Detections: 0.',
+    );
+    expect(reader.unpdfProvider.renderPages).toHaveBeenCalledWith(
+      '/tmp/scanned.pdf',
+      expect.objectContaining({
+        scale: 2,
+        throwOnError: true,
+      }),
+    );
+  });
+
+  it('surfaces OCR fallback rendering failures instead of returning null', async () => {
+    const reader = new CombinedNodeProvider() as any;
+
+    reader.unpdfProvider = {
+      extractText: vi.fn().mockResolvedValue(''),
+      getInfo: vi.fn().mockResolvedValue({ pageCount: 1 }),
+      renderPages: vi.fn().mockRejectedValue(new Error('canvas unavailable')),
+    };
+    reader.ocrFactory = {
+      performOCR: vi.fn(),
+    };
+
+    await expect(reader.extractText('/tmp/scanned.pdf')).rejects.toBeInstanceOf(
+      PDFOCRFallbackError,
+    );
+    await expect(reader.extractText('/tmp/scanned.pdf')).rejects.toThrow(
+      'OCR fallback failed for all pages: canvas unavailable',
+    );
+    expect(reader.ocrFactory.performOCR).not.toHaveBeenCalled();
   });
 
   it('merges explicit OCR options over configured defaults', async () => {
@@ -683,6 +753,73 @@ describe('UnpdfProvider', () => {
       expect(document.cleanup).toHaveBeenCalledOnce();
       expect(document.destroy).toHaveBeenCalledOnce();
     }
+  });
+
+  it('rejects collected image extraction before retaining unbounded image bytes', async () => {
+    const reader = new UnpdfProvider() as any;
+
+    reader.loadUnpdf = vi.fn().mockResolvedValue({
+      getDocumentProxy: vi.fn().mockResolvedValue({
+        numPages: 3,
+        cleanup: vi.fn(),
+        destroy: vi.fn(),
+      }),
+      extractImages: vi.fn().mockImplementation(async (_pdf, pageNumber) => [
+        {
+          data: Buffer.alloc(6, pageNumber),
+          width: 1,
+          height: 6,
+          channels: 1,
+        },
+      ]),
+    });
+    reader.normalizeSource = vi
+      .fn()
+      .mockResolvedValue(new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d]));
+    reader.validatePDFData = vi.fn().mockReturnValue(true);
+
+    await expect(
+      reader.extractImages('/tmp/large.pdf', {
+        batchSize: 1,
+        maxCollectedBytes: 10,
+      }),
+    ).rejects.toBeInstanceOf(PDFImageCollectionLimitError);
+  });
+
+  it('allows streaming image extraction without collection even when batches exceed the collection limit', async () => {
+    const reader = new UnpdfProvider() as any;
+
+    reader.loadUnpdf = vi.fn().mockResolvedValue({
+      getDocumentProxy: vi.fn().mockResolvedValue({
+        numPages: 2,
+        cleanup: vi.fn(),
+        destroy: vi.fn(),
+      }),
+      extractImages: vi.fn().mockImplementation(async (_pdf, pageNumber) => [
+        {
+          data: Buffer.alloc(12, pageNumber),
+          width: 1,
+          height: 12,
+          channels: 1,
+        },
+      ]),
+    });
+    reader.normalizeSource = vi
+      .fn()
+      .mockResolvedValue(new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d]));
+    reader.validatePDFData = vi.fn().mockReturnValue(true);
+
+    const seenPages: number[] = [];
+    const images = await reader.extractImages('/tmp/large.pdf', {
+      batchSize: 1,
+      maxCollectedBytes: 0,
+      onBatch: ({ pages }) => {
+        seenPages.push(...pages);
+      },
+    });
+
+    expect(images).toEqual([]);
+    expect(seenPages).toEqual([1, 2]);
   });
 
   it('passes file-backed getInfo sources through without forcing an extra buffer clone', async () => {

--- a/src/node/combined.test.ts
+++ b/src/node/combined.test.ts
@@ -214,6 +214,101 @@ describe('CombinedNodeProvider', () => {
     expect(reader.ocrFactory.performOCR).toHaveBeenCalledTimes(3);
   });
 
+  it('continues large OCR extraction when one batch has no recognized text', async () => {
+    const reader = new CombinedNodeProvider() as any;
+    reader.getSourceByteLength = vi.fn().mockResolvedValue(30 * 1024 * 1024);
+
+    reader.getInfo = vi.fn().mockResolvedValue({
+      pageCount: 5,
+      fileSize: 30 * 1024 * 1024,
+      encrypted: false,
+      hasEmbeddedText: false,
+      hasImages: true,
+      recommendedStrategy: 'ocr',
+      ocrRequired: true,
+      estimatedProcessingTime: {
+        textExtraction: 'slow',
+        ocrProcessing: 'slow',
+      },
+    });
+
+    reader.unpdfProvider = {
+      renderPages: vi.fn().mockImplementation(async (_source, options) => {
+        return (options?.pages ?? []).map((pageNumber: number) => ({
+          data: Buffer.from([pageNumber]),
+          format: 'rgb',
+          width: 10,
+          height: 10,
+          channels: 3,
+          pageNumber,
+        }));
+      }),
+    };
+    reader.ocrFactory = {
+      performOCR: vi
+        .fn()
+        .mockResolvedValueOnce({
+          text: '',
+          confidence: 0,
+        })
+        .mockResolvedValueOnce({
+          text: 'ocr:5',
+          confidence: 99,
+        }),
+    };
+
+    await expect(
+      reader.extractText('/tmp/scanned.pdf', { mergePages: true }),
+    ).resolves.toBe('ocr:5');
+    expect(reader.unpdfProvider.renderPages).toHaveBeenCalledTimes(2);
+    expect(reader.ocrFactory.performOCR).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws an explicit OCR fallback error when every OCR batch is empty', async () => {
+    const reader = new CombinedNodeProvider() as any;
+    reader.getSourceByteLength = vi.fn().mockResolvedValue(30 * 1024 * 1024);
+
+    reader.getInfo = vi.fn().mockResolvedValue({
+      pageCount: 5,
+      fileSize: 30 * 1024 * 1024,
+      encrypted: false,
+      hasEmbeddedText: false,
+      hasImages: true,
+      recommendedStrategy: 'ocr',
+      ocrRequired: true,
+      estimatedProcessingTime: {
+        textExtraction: 'slow',
+        ocrProcessing: 'slow',
+      },
+    });
+
+    reader.unpdfProvider = {
+      renderPages: vi.fn().mockImplementation(async (_source, options) => {
+        return (options?.pages ?? []).map((pageNumber: number) => ({
+          data: Buffer.from([pageNumber]),
+          format: 'rgb',
+          width: 10,
+          height: 10,
+          channels: 3,
+          pageNumber,
+        }));
+      }),
+    };
+    reader.ocrFactory = {
+      performOCR: vi.fn().mockResolvedValue({
+        text: '',
+        confidence: 0,
+      }),
+    };
+
+    await expect(
+      reader.extractText('/tmp/scanned.pdf', { mergePages: true }),
+    ).rejects.toBeInstanceOf(PDFOCRFallbackError);
+    await expect(
+      reader.extractText('/tmp/scanned.pdf', { mergePages: true }),
+    ).rejects.toThrow('OCR fallback produced no text for pages 1-5.');
+  });
+
   it('applies default OCR options during automatic OCR fallback', async () => {
     const reader = new CombinedNodeProvider({
       defaultOCROptions: {
@@ -296,6 +391,25 @@ describe('CombinedNodeProvider', () => {
         throwOnError: true,
       }),
     );
+  });
+
+  it('returns null for invalid OCR fallback pages without rendering', async () => {
+    const reader = new CombinedNodeProvider() as any;
+
+    reader.unpdfProvider = {
+      extractText: vi.fn().mockResolvedValue(''),
+      getInfo: vi.fn().mockResolvedValue({ pageCount: 2 }),
+      renderPages: vi.fn(),
+    };
+    reader.ocrFactory = {
+      performOCR: vi.fn(),
+    };
+
+    await expect(
+      reader.extractText('/tmp/scanned.pdf', { pages: [99] }),
+    ).resolves.toBeNull();
+    expect(reader.unpdfProvider.renderPages).not.toHaveBeenCalled();
+    expect(reader.ocrFactory.performOCR).not.toHaveBeenCalled();
   });
 
   it('surfaces OCR fallback rendering failures instead of returning null', async () => {

--- a/src/node/combined.ts
+++ b/src/node/combined.ts
@@ -17,7 +17,11 @@ import type {
   PDFMetadata,
   PDFSource,
 } from '../shared/types';
-import { PDFBatchExtractionError, PDFFileSizeError } from '../shared/types';
+import {
+  PDFBatchExtractionError,
+  PDFFileSizeError,
+  PDFOCRFallbackError,
+} from '../shared/types';
 import {
   canUseChildExtraction,
   extractTextInChildProcess,
@@ -90,7 +94,7 @@ export class CombinedNodeProvider extends BasePDFReader {
       return source.byteLength === 0;
     }
 
-    return false;
+    return typeof source === 'object' && Object.keys(source).length === 0;
   }
 
   private async getSourceByteLength(
@@ -217,6 +221,16 @@ export class CombinedNodeProvider extends BasePDFReader {
     return TEXT_BATCH_SIZE;
   }
 
+  private formatPagesLabel(pages?: number[]): string {
+    if (!pages?.length) {
+      return 'all pages';
+    }
+
+    return pages.length > 1
+      ? `pages ${pages[0]}-${pages[pages.length - 1]}`
+      : `page ${pages[0]}`;
+  }
+
   private async extractTextPageWise(
     source: PDFSource,
     pages: number[],
@@ -262,26 +276,52 @@ export class CombinedNodeProvider extends BasePDFReader {
 
   private async extractOcrBatch(
     source: PDFSource,
-    pages: number[],
+    pages?: number[],
   ): Promise<OCRResult> {
     const renderedPages = await this.unpdfProvider.renderPages(source, {
       scale: 2.0,
+      throwOnError: true,
       pages,
     });
 
     if (!renderedPages.length) {
-      return {
-        text: '',
-        confidence: 0,
-      };
+      throw new PDFOCRFallbackError(
+        `OCR fallback could not render ${this.formatPagesLabel(pages)}; renderPages returned no page images.`,
+        pages,
+      );
     }
 
-    return this.ocrFactory.performOCR(renderedPages, this.mergeOCROptions());
+    const ocrResult = await this.ocrFactory.performOCR(
+      renderedPages,
+      this.mergeOCROptions(),
+    );
+    const ocrText = ocrResult.text?.trim() || '';
+
+    if (!ocrText) {
+      const metadataProvider =
+        typeof ocrResult.metadata?.provider === 'string'
+          ? ` Provider: ${ocrResult.metadata.provider}.`
+          : '';
+      const confidence =
+        typeof ocrResult.confidence === 'number'
+          ? ` Confidence: ${ocrResult.confidence.toFixed(1)}.`
+          : '';
+      const detectionCount = Array.isArray(ocrResult.detections)
+        ? ` Detections: ${ocrResult.detections.length}.`
+        : '';
+
+      throw new PDFOCRFallbackError(
+        `OCR fallback produced no text for ${this.formatPagesLabel(pages)}.${metadataProvider}${confidence}${detectionCount}`,
+        pages,
+      );
+    }
+
+    return ocrResult;
   }
 
   private async extractOcrBatchText(
     source: PDFSource,
-    pages: number[],
+    pages?: number[],
   ): Promise<string> {
     const ocrResult = await this.extractOcrBatch(source, pages);
     return ocrResult.text?.trim() || '';
@@ -430,23 +470,24 @@ export class CombinedNodeProvider extends BasePDFReader {
       if (!text?.trim() && !options?.skipOCRFallback) {
         console.log('No direct text found, attempting OCR fallback...');
 
-        try {
-          // Use renderPages() instead of extractImages() for full-page OCR
-          // This renders the PDF pages as images, capturing all text as pixels
-          const renderedPages = await this.unpdfProvider.renderPages(source, {
-            scale: 2.0, // 2x scale for better OCR quality
-            pages: options?.pages, // Respect page selection if provided
-          });
+        const fallbackInfo = await this.unpdfProvider.getInfo(source);
+        if (fallbackInfo.pageCount <= 0) {
+          return text;
+        }
 
-          if (renderedPages && renderedPages.length > 0) {
-            const ocrResult = await this.ocrFactory.performOCR(
-              renderedPages,
-              this.mergeOCROptions(),
-            );
-            return ocrResult.text || null;
-          }
+        try {
+          return await this.extractOcrBatchText(source, options?.pages);
         } catch (ocrError) {
-          console.warn('OCR fallback failed:', ocrError);
+          if (ocrError instanceof PDFOCRFallbackError) {
+            throw ocrError;
+          }
+
+          const message =
+            ocrError instanceof Error ? ocrError.message : String(ocrError);
+          throw new PDFOCRFallbackError(
+            `OCR fallback failed for ${this.formatPagesLabel(options?.pages)}: ${message}`,
+            options?.pages,
+          );
         }
       }
 
@@ -454,7 +495,8 @@ export class CombinedNodeProvider extends BasePDFReader {
     } catch (error) {
       if (
         error instanceof PDFBatchExtractionError ||
-        error instanceof PDFFileSizeError
+        error instanceof PDFFileSizeError ||
+        error instanceof PDFOCRFallbackError
       ) {
         throw error;
       }

--- a/src/node/combined.ts
+++ b/src/node/combined.ts
@@ -226,9 +226,17 @@ export class CombinedNodeProvider extends BasePDFReader {
       return 'all pages';
     }
 
-    return pages.length > 1
+    if (pages.length === 1) {
+      return `page ${pages[0]}`;
+    }
+
+    const isContiguous = pages.every(
+      (page, index) => index === 0 || page === pages[index - 1] + 1,
+    );
+
+    return isContiguous
       ? `pages ${pages[0]}-${pages[pages.length - 1]}`
-      : `page ${pages[0]}`;
+      : `pages ${pages.join(', ')}`;
   }
 
   private async extractTextPageWise(
@@ -274,9 +282,39 @@ export class CombinedNodeProvider extends BasePDFReader {
     ).trim();
   }
 
+  private createEmptyOcrTextError(
+    ocrResult: OCRResult,
+    pages?: number[],
+  ): PDFOCRFallbackError {
+    const metadataProvider =
+      typeof ocrResult.metadata?.provider === 'string'
+        ? ` Provider: ${ocrResult.metadata.provider}.`
+        : '';
+    const confidence =
+      typeof ocrResult.confidence === 'number'
+        ? ` Confidence: ${ocrResult.confidence.toFixed(1)}.`
+        : '';
+    const detectionCount = Array.isArray(ocrResult.detections)
+      ? ` Detections: ${ocrResult.detections.length}.`
+      : '';
+
+    return new PDFOCRFallbackError(
+      `OCR fallback produced no text for ${this.formatPagesLabel(pages)}.${metadataProvider}${confidence}${detectionCount}`,
+      pages,
+    );
+  }
+
+  private createEmptyBatchedOcrTextError(pages: number[]): PDFOCRFallbackError {
+    return new PDFOCRFallbackError(
+      `OCR fallback produced no text for ${this.formatPagesLabel(pages)}.`,
+      pages,
+    );
+  }
+
   private async extractOcrBatch(
     source: PDFSource,
     pages?: number[],
+    options: { requireText?: boolean } = {},
   ): Promise<OCRResult> {
     const renderedPages = await this.unpdfProvider.renderPages(source, {
       scale: 2.0,
@@ -297,23 +335,8 @@ export class CombinedNodeProvider extends BasePDFReader {
     );
     const ocrText = ocrResult.text?.trim() || '';
 
-    if (!ocrText) {
-      const metadataProvider =
-        typeof ocrResult.metadata?.provider === 'string'
-          ? ` Provider: ${ocrResult.metadata.provider}.`
-          : '';
-      const confidence =
-        typeof ocrResult.confidence === 'number'
-          ? ` Confidence: ${ocrResult.confidence.toFixed(1)}.`
-          : '';
-      const detectionCount = Array.isArray(ocrResult.detections)
-        ? ` Detections: ${ocrResult.detections.length}.`
-        : '';
-
-      throw new PDFOCRFallbackError(
-        `OCR fallback produced no text for ${this.formatPagesLabel(pages)}.${metadataProvider}${confidence}${detectionCount}`,
-        pages,
-      );
+    if (options.requireText && !ocrText) {
+      throw this.createEmptyOcrTextError(ocrResult, pages);
     }
 
     return ocrResult;
@@ -322,8 +345,9 @@ export class CombinedNodeProvider extends BasePDFReader {
   private async extractOcrBatchText(
     source: PDFSource,
     pages?: number[],
+    options?: { requireText?: boolean },
   ): Promise<string> {
-    const ocrResult = await this.extractOcrBatch(source, pages);
+    const ocrResult = await this.extractOcrBatch(source, pages, options);
     return ocrResult.text?.trim() || '';
   }
 
@@ -386,7 +410,15 @@ export class CombinedNodeProvider extends BasePDFReader {
         options,
       );
       const mergedText = this.mergePageTexts(pageTexts, false);
-      return mergedText.trim() ? mergedText : null;
+      if (mergedText.trim()) {
+        return mergedText;
+      }
+
+      if (strategy === 'ocr') {
+        throw this.createEmptyBatchedOcrTextError(pagesToExtract);
+      }
+
+      return null;
     }
 
     const batchTexts: string[] = [];
@@ -415,7 +447,16 @@ export class CombinedNodeProvider extends BasePDFReader {
     }
 
     const mergedText = this.mergePageTexts(batchTexts, options?.mergePages);
-    return mergedText.trim() ? mergedText : null;
+    const trimmedText = mergedText.trim();
+    if (trimmedText) {
+      return options?.mergePages === true ? trimmedText : mergedText;
+    }
+
+    if (strategy === 'ocr') {
+      throw this.createEmptyBatchedOcrTextError(pagesToExtract);
+    }
+
+    return null;
   }
 
   /**
@@ -475,8 +516,18 @@ export class CombinedNodeProvider extends BasePDFReader {
           return text;
         }
 
+        const fallbackPages = options?.pages
+          ? this.normalizePages(options.pages, fallbackInfo.pageCount)
+          : undefined;
+
+        if (options?.pages && !fallbackPages?.length) {
+          return text?.trim() ? text : null;
+        }
+
         try {
-          return await this.extractOcrBatchText(source, options?.pages);
+          return await this.extractOcrBatchText(source, fallbackPages, {
+            requireText: true,
+          });
         } catch (ocrError) {
           if (ocrError instanceof PDFOCRFallbackError) {
             throw ocrError;
@@ -485,8 +536,8 @@ export class CombinedNodeProvider extends BasePDFReader {
           const message =
             ocrError instanceof Error ? ocrError.message : String(ocrError);
           throw new PDFOCRFallbackError(
-            `OCR fallback failed for ${this.formatPagesLabel(options?.pages)}: ${message}`,
-            options?.pages,
+            `OCR fallback failed for ${this.formatPagesLabel(fallbackPages)}: ${message}`,
+            fallbackPages,
           );
         }
       }

--- a/src/node/unpdf.ts
+++ b/src/node/unpdf.ts
@@ -29,11 +29,17 @@ import type {
   PDFSource,
   RenderPagesOptions,
 } from '../shared/types';
-import { PDFBatchExtractionError, PDFDependencyError } from '../shared/types';
+import {
+  PDFBatchExtractionError,
+  PDFDependencyError,
+  PDFImageCollectionLimitError,
+  PDFOCRFallbackError,
+} from '../shared/types';
 import { formatPdfOcrRuntimeIssue } from './ocr-runtime';
 
 const require = createRequire(import.meta.url);
 const IMAGE_EXTRACTION_BATCH_SIZE = 4;
+const DEFAULT_MAX_COLLECTED_IMAGE_BYTES = 128 * 1024 * 1024;
 
 type UnpdfModule = typeof import('unpdf');
 type UnpdfDocumentProxy = Awaited<ReturnType<UnpdfModule['getDocumentProxy']>>;
@@ -412,6 +418,26 @@ export class UnpdfProvider extends BasePDFReader {
     return Math.floor(batchSize);
   }
 
+  private normalizeMaxCollectedImageBytes(maxCollectedBytes?: number): number {
+    if (maxCollectedBytes === undefined) {
+      return DEFAULT_MAX_COLLECTED_IMAGE_BYTES;
+    }
+
+    if (!Number.isFinite(maxCollectedBytes) || maxCollectedBytes < 0) {
+      return DEFAULT_MAX_COLLECTED_IMAGE_BYTES;
+    }
+
+    return Math.floor(maxCollectedBytes);
+  }
+
+  private getImageByteLength(image: PDFImage): number {
+    if (typeof image.data === 'string') {
+      return Buffer.byteLength(image.data);
+    }
+
+    return image.data.byteLength;
+  }
+
   private chunkPages(pages: number[], batchSize: number): number[][] {
     const batches: number[][] = [];
 
@@ -594,7 +620,11 @@ export class UnpdfProvider extends BasePDFReader {
       this.normalizeImageBatchSize(options?.batchSize),
     );
     const shouldCollect = options?.collect ?? !options?.onBatch;
+    const maxCollectedBytes = this.normalizeMaxCollectedImageBytes(
+      options?.maxCollectedBytes,
+    );
     const allImages: PDFImage[] = [];
+    let collectedBytes = 0;
 
     for (const [batchIndex, pages] of batches.entries()) {
       let images: PDFImage[];
@@ -610,6 +640,22 @@ export class UnpdfProvider extends BasePDFReader {
         throw new PDFBatchExtractionError(pages, message);
       }
 
+      let nextCollectedBytes = collectedBytes;
+
+      if (shouldCollect) {
+        const batchBytes = images.reduce(
+          (total, image) => total + this.getImageByteLength(image),
+          0,
+        );
+        nextCollectedBytes = collectedBytes + batchBytes;
+        if (nextCollectedBytes > maxCollectedBytes) {
+          throw new PDFImageCollectionLimitError(
+            nextCollectedBytes,
+            maxCollectedBytes,
+          );
+        }
+      }
+
       await options?.onBatch?.({
         images,
         pages,
@@ -621,6 +667,7 @@ export class UnpdfProvider extends BasePDFReader {
         for (const image of images) {
           allImages.push(image);
         }
+        collectedBytes = nextCollectedBytes;
       }
     }
 
@@ -705,10 +752,14 @@ export class UnpdfProvider extends BasePDFReader {
         await document.destroy();
       }
     } catch (error) {
-      console.error(
-        'unpdf page rendering failed:',
-        formatPdfOcrRuntimeIssue(error),
-      );
+      const message = formatPdfOcrRuntimeIssue(error);
+      console.error('unpdf page rendering failed:', message);
+      if (options?.throwOnError) {
+        throw new PDFOCRFallbackError(
+          `PDF page rendering failed during OCR fallback: ${message}`,
+          options.pages,
+        );
+      }
       return [];
     }
   }

--- a/src/node/unpdf.ts
+++ b/src/node/unpdf.ts
@@ -685,14 +685,7 @@ export class UnpdfProvider extends BasePDFReader {
     options?: RenderPagesOptions,
   ): Promise<PDFImage[]> {
     // Handle invalid inputs gracefully
-    if (
-      !source ||
-      (typeof source === 'string' && source.trim() === '') ||
-      (typeof source === 'object' &&
-        Object.keys(source).length === 0 &&
-        !(source instanceof Buffer) &&
-        !(source instanceof Uint8Array))
-    ) {
+    if (this.isInvalidSource(source)) {
       return [];
     }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -61,6 +61,8 @@ export interface RenderPagesOptions {
   scale?: number;
   /** Specific pages to render (1-based indexing). If not provided, renders all pages */
   pages?: number[];
+  /** Whether rendering failures should be thrown instead of returning an empty list */
+  throwOnError?: boolean;
   /** Temporary folder for storing rendered images */
   outputFolder?: string;
   /** Whether to clean up rendered image files after processing */
@@ -136,6 +138,13 @@ export interface ExtractImagesOptions {
   pages?: number[];
   /** Number of pages to process per provider batch. Defaults to a small bounded batch size */
   batchSize?: number;
+  /**
+   * Maximum total image bytes to retain in the returned array when collecting.
+   *
+   * Defaults to a bounded safety limit. Streaming callers should provide onBatch
+   * and leave collect unset/false to avoid retaining image bytes.
+   */
+  maxCollectedBytes?: number;
   /**
    * Whether to accumulate extracted images into the returned array.
    *
@@ -612,6 +621,31 @@ export class PDFBatchExtractionError extends PDFError {
     );
     this.code = 'EBATCH';
     this.name = 'PDFBatchExtractionError';
+  }
+}
+
+export class PDFImageCollectionLimitError extends PDFError {
+  constructor(
+    public actualSizeBytes: number,
+    public maxSizeBytes: number,
+  ) {
+    const actualMB = (actualSizeBytes / 1024 / 1024).toFixed(1);
+    const limitMB = (maxSizeBytes / 1024 / 1024).toFixed(1);
+    super(
+      `PDF image extraction would collect ${actualMB}MB of image data, exceeding the ${limitMB}MB safety limit. Use extractImages(source, { onBatch, collect: false }) to process image batches incrementally, or raise maxCollectedBytes for trusted inputs.`,
+    );
+    this.code = 'EIMAGELIMIT';
+    this.name = 'PDFImageCollectionLimitError';
+  }
+}
+
+export class PDFOCRFallbackError extends PDFError {
+  constructor(
+    message: string,
+    public pages?: number[],
+  ) {
+    super(message, 'EOCRFALLBACK');
+    this.name = 'PDFOCRFallbackError';
   }
 }
 


### PR DESCRIPTION
## Summary

- Make OCR fallback fail explicitly with `PDFOCRFallbackError` when page rendering fails or OCR returns no recognized text, while preserving graceful `null` behavior for invalid/missing/corrupt inputs.
- Add a collected-image byte ceiling with `PDFImageCollectionLimitError` so large image-heavy PDFs use the existing batched `onBatch` path instead of retaining unbounded image buffers.
- Document the large-PDF image extraction path and add a patch changeset for one release covering pdf#70 and pdf#71.

Fixes #70
Fixes #71

## Validation

- `pnpm exec tsc --noEmit`
- `CI=true pnpm test`
- `pnpm run build`
- focused touched-file `biome check`
- live Bentley March 24, 2026 minutes PDF extracted 6063 characters through the built package