### PR TITLE
feat(pdf): web-safe image output + canonical mime types (#73, #74)

### DIFF
--- a/.changeset/web-safe-image-extraction.md
+++ b/.changeset/web-safe-image-extraction.md
@@ -1,0 +1,24 @@
+---
+'@happyvertical/pdf': minor
+---
+
+Make `extractImages` produce web-safe output by default and standardize `PDFImage.format` to canonical IANA mime types.
+
+Closes #73, closes #74. Companion to https://github.com/happyvertical/ocr/issues/75 (PR #76) — `PDFImage` now also carries `bitsPerComponent`, so consumers can decode raw pixel buffers without ambiguous heuristics.
+
+### What changed
+
+- `extractImages(source, options)` now accepts `outputFormat: 'webp' | 'png' | 'jpeg' | 'original'` and re-encodes raw image streams via `@napi-rs/canvas`. The default is `'webp'` so callers can store / serve `image.data` directly.
+- `renderPages(source, options)` accepts the same `outputFormat` option. Default remains `'original'` (raw 8-bit RGB) so the OCR fallback path stays zero-copy.
+- `PDFImage.format` is now a canonical lowercase IANA mime type (`image/jpeg`, `image/png`, `image/webp`, `image/x-rgb`, `image/x-rgba`, `image/x-grayscale`, `image/x-cmyk`, or `application/octet-stream`) instead of provider-specific values like `'rgb'` or `'unknown'`.
+- `PDFImage.bitsPerComponent` is populated for raw pixel outputs (always `8` from unpdf), unblocking the planned `OCRImage.bitsPerComponent` field upstream.
+- New exports: `canonicalizeImageFormat(format, channels?)` (pure helper) and `encodePDFImage(image, target?, options?)` (lazy Node-only re-encoder).
+
+### Migration
+
+- Callers that consumed raw RGB bytes (`format === 'rgb'`) should pass `outputFormat: 'original'` to keep the previous behavior, and update format checks to `image.format === 'image/x-rgb'`.
+- Callers that re-encoded extracted images downstream (e.g. via `sharp`) can drop their re-encoder; `image.data` is now WebP by default.
+- Streaming callers using `extractImages(source, { onBatch })` are also affected: each batch's `images[].data` is now WebP unless `outputFormat: 'original'` is passed.
+- OCR-on-extracted-images flows that fed `extractImages()` results directly into `performOCR()` should pass `outputFormat: 'original'` (raw RGB is the OCR fast path) or the encoded format their OCR provider supports. Internal OCR fallback (`extractText()` / `renderPages()` → OCR) is unaffected.
+- Encoded outputs (`outputFormat: 'webp' | 'png' | 'jpeg'`) drop `channels` and `bitsPerComponent` from the returned `PDFImage` so the encoded buffer cannot be misinterpreted as raw pixel data by OCR providers that key on `width && height && channels`. `width` and `height` remain set as metadata.
+- Raw outputs (`outputFormat: 'original'`) now also carry `bitsPerComponent: 8`, so consumers can decode the buffer unambiguously without the 1-channel-16-bit vs. 2-channel-8-bit collision (companion to https://github.com/happyvertical/ocr/issues/75).

--- a/package.json
+++ b/package.json
@@ -15,11 +15,7 @@
       "pdfjs-dist": "5.4.296"
     }
   },
-  "files": [
-    "dist",
-    "README.md",
-    "LICENSE"
-  ],
+  "files": ["dist", "README.md", "LICENSE"],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com",
     "access": "public"

--- a/src/extraction.test.ts
+++ b/src/extraction.test.ts
@@ -55,6 +55,61 @@ describe('PDF Content Extraction', () => {
     }
   });
 
+  it('should default extractImages to web-safe webp output (issue #73)', async () => {
+    // Default behavior: re-encode raw RGB streams to webp so callers can
+    // store / serve `image.data` directly.
+    const images = await unpdfReader.extractImages(pdfPath);
+
+    expect(images.length).toBe(3);
+    for (const image of images) {
+      expect(image.format).toBe('image/webp');
+      // WebP signature: bytes 0-3 = "RIFF", bytes 8-11 = "WEBP"
+      const buf = image.data as Buffer;
+      const header = buf.subarray(0, 4).toString('ascii');
+      const signature = buf.subarray(8, 12).toString('ascii');
+      expect(header).toBe('RIFF');
+      expect(signature).toBe('WEBP');
+      // Encoded outputs intentionally drop bitsPerComponent.
+      expect(image.bitsPerComponent).toBeUndefined();
+    }
+  });
+
+  it('should expose canonical mime types and bitsPerComponent on raw output (issues #73 + #74 + ocr#75)', async () => {
+    const images = await unpdfReader.extractImages(pdfPath, {
+      outputFormat: 'original',
+    });
+
+    expect(images.length).toBe(3);
+    for (const image of images) {
+      // Canonical IANA mime types only — no 'rgb', 'unknown', etc.
+      expect(image.format).toMatch(
+        /^(image\/x-rgb|image\/x-rgba|image\/x-grayscale|image\/x-cmyk|image\/jpeg|image\/png|application\/octet-stream)$/,
+      );
+      // Raw 8-bit pixel buffers carry bitsPerComponent so consumers can
+      // decode the buffer without guessing (ocr#75).
+      if (image.format?.startsWith('image/x-')) {
+        expect(image.bitsPerComponent).toBe(8);
+      }
+    }
+  });
+
+  it('should re-encode extractImages output to png on demand', async () => {
+    const images = await unpdfReader.extractImages(pdfPath, {
+      outputFormat: 'png',
+    });
+
+    expect(images.length).toBe(3);
+    for (const image of images) {
+      expect(image.format).toBe('image/png');
+      // PNG signature
+      const buf = image.data as Buffer;
+      expect(buf[0]).toBe(0x89);
+      expect(buf[1]).toBe(0x50);
+      expect(buf[2]).toBe(0x4e);
+      expect(buf[3]).toBe(0x47);
+    }
+  });
+
   it('should keep image extraction working with the auto reader', async () => {
     const images = await reader.extractImages(pdfPath);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,9 +17,38 @@ export {
 } from './shared/factory';
 export * from './shared/types';
 
+// Pure helper — safe in any environment. Use this when you only need to
+// normalize a `format` string to a canonical IANA mime type per issue #74.
+export { canonicalizeImageFormat } from './shared/image-format';
+
+import type {
+  ImageEncodingOptions,
+  PDFImage,
+  PDFImageOutputFormat,
+} from './shared/types';
+
+/**
+ * Re-encode an already-extracted `PDFImage` to a web-safe format.
+ *
+ * Companion to `extractImages({ outputFormat })` (issue #73). Use this when
+ * the original extraction returned `outputFormat: 'original'` and the
+ * caller now wants a web-safe asset.
+ *
+ * Node-only at runtime: the encoder is loaded lazily so that importing
+ * `@happyvertical/pdf` from a browser context does not pull in
+ * `@napi-rs/canvas` until you actually call this function.
+ */
+export async function encodePDFImage(
+  image: PDFImage,
+  target: PDFImageOutputFormat = 'webp',
+  options?: ImageEncodingOptions,
+): Promise<PDFImage> {
+  const mod = await import('./node/image-encoding');
+  return mod.encodePDFImage(image, target, options);
+}
+
 // Legacy compatibility exports for backward compatibility with existing code
 import { getPDFReader, initializeProviders } from './shared/factory';
-import type { PDFImage } from './shared/types';
 
 /**
  * Extract text from a PDF file (legacy compatibility)

--- a/src/node/combined.test.ts
+++ b/src/node/combined.test.ts
@@ -846,6 +846,10 @@ describe('UnpdfProvider', () => {
     const seenBatches: number[][] = [];
     const result = await reader.extractImages('/tmp/large.pdf', {
       batchSize: 2,
+      // This test exercises batch streaming + cleanup; pin to raw output so
+      // mocked byte buffers flow through unchanged (webp encoding would
+      // turn the 1MB raw buffers into compressed payloads).
+      outputFormat: 'original',
       onBatch: async ({ images, pages, batchIndex, totalBatches }) => {
         seenBatches.push(pages);
         expect(images.map((image) => image.pageNumber)).toEqual(pages);
@@ -1028,6 +1032,9 @@ describe('UnpdfProvider', () => {
     const images = await reader.extractImages('/tmp/document.pdf', {
       pages: [2, 4, 5],
       batchSize: 2,
+      // This test asserts on the raw mocked bytes, so pin to 'original'.
+      // Encoding is covered separately in image-encoding.test.ts.
+      outputFormat: 'original',
     });
 
     expect(images.map((image) => image.pageNumber)).toEqual([2, 2, 4, 4, 5, 5]);

--- a/src/node/combined.test.ts
+++ b/src/node/combined.test.ts
@@ -1125,4 +1125,69 @@ describe('UnpdfProvider', () => {
       }),
     ).rejects.toBe(batchError);
   });
+
+  it('sniffs encoded JPEG/PNG streams instead of mislabelling them as raw RGB (issue #74 review)', async () => {
+    // Codex / Copilot review on PR #75: when the upstream returns a
+    // 3-channel image whose bytes are an encoded JPEG/PNG stream (byte
+    // length does not match width*height*channels), we must not label it
+    // image/x-rgb just because channels === 3.
+    const reader = new UnpdfProvider() as any;
+    const jpegPayload = Buffer.from([
+      0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46,
+    ]);
+    const pngPayload = Buffer.from([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
+    ]);
+    const rawRgbPayload = Buffer.alloc(2 * 2 * 3, 200); // 2x2 RGB
+    const opaqueGarbage = Buffer.from([0x00, 0x01, 0x02, 0x03]);
+
+    reader.loadUnpdf = vi.fn().mockResolvedValue({
+      getDocumentProxy: vi.fn().mockResolvedValue({
+        numPages: 4,
+        cleanup: vi.fn(),
+        destroy: vi.fn(),
+      }),
+      extractImages: vi
+        .fn()
+        .mockImplementation(async (_pdf, pageNumber: number) => {
+          if (pageNumber === 1) {
+            return [
+              { data: jpegPayload, width: 100, height: 100, channels: 3 },
+            ];
+          }
+          if (pageNumber === 2) {
+            return [{ data: pngPayload, width: 100, height: 100, channels: 4 }];
+          }
+          if (pageNumber === 3) {
+            return [{ data: rawRgbPayload, width: 2, height: 2, channels: 3 }];
+          }
+          return [{ data: opaqueGarbage, width: 99, height: 99, channels: 3 }];
+        }),
+    });
+    reader.normalizeSource = vi
+      .fn()
+      .mockResolvedValue(new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d]));
+    reader.validatePDFData = vi.fn().mockReturnValue(true);
+
+    const images = await reader.extractImages('/tmp/document.pdf', {
+      pages: [1, 2, 3, 4],
+      batchSize: 4,
+      // Pin to 'original' so we observe the format inferred by the
+      // extractor, not the encoding output's mime.
+      outputFormat: 'original',
+    });
+
+    expect(images.map((image: any) => image.format)).toEqual([
+      'image/jpeg', // sniffed from FF D8 FF — not labelled image/x-rgb
+      'image/png', // sniffed from PNG signature — not labelled image/x-rgba
+      'image/x-rgb', // byte length matches raw layout
+      'application/octet-stream', // no signature, no raw layout
+    ]);
+    // Encoded streams should not carry bitsPerComponent (they're not raw).
+    expect(images[0].bitsPerComponent).toBeUndefined();
+    expect(images[1].bitsPerComponent).toBeUndefined();
+    expect(images[3].bitsPerComponent).toBeUndefined();
+    // Raw layout still carries bps so consumers can decode unambiguously.
+    expect(images[2].bitsPerComponent).toBe(8);
+  });
 });

--- a/src/node/image-encoding.test.ts
+++ b/src/node/image-encoding.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Unit tests for the image-encoding helpers introduced for issues
+ * #73 (web-safe output) and #74 (canonical mime types).
+ */
+
+import { describe, expect, it } from 'vitest';
+import { canonicalizeImageFormat } from '../shared/image-format';
+import type { PDFImage } from '../shared/types';
+import { encodePDFImage } from './image-encoding';
+
+function makeRawRGBImage(width = 4, height = 4): PDFImage {
+  // 4x4 solid red — easy to verify across encodings.
+  const data = Buffer.alloc(width * height * 3);
+  for (let i = 0; i < width * height; i++) {
+    data[i * 3] = 255;
+    data[i * 3 + 1] = 0;
+    data[i * 3 + 2] = 0;
+  }
+  return {
+    data,
+    width,
+    height,
+    channels: 3,
+    bitsPerComponent: 8,
+    format: 'image/x-rgb',
+    pageNumber: 1,
+  };
+}
+
+describe('canonicalizeImageFormat (issue #74)', () => {
+  it('maps the documented variants to canonical IANA mime types', () => {
+    expect(canonicalizeImageFormat('jpeg')).toBe('image/jpeg');
+    expect(canonicalizeImageFormat('jpg')).toBe('image/jpeg');
+    expect(canonicalizeImageFormat('image/jpg')).toBe('image/jpeg');
+    expect(canonicalizeImageFormat('image/jpeg; charset=binary')).toBe(
+      'image/jpeg',
+    );
+    expect(canonicalizeImageFormat('image/x-png')).toBe('image/png');
+    expect(canonicalizeImageFormat('PNG')).toBe('image/png');
+    expect(canonicalizeImageFormat('webp')).toBe('image/webp');
+    expect(canonicalizeImageFormat('tiff')).toBe('image/tiff');
+    expect(canonicalizeImageFormat('image/tif')).toBe('image/tiff');
+    expect(canonicalizeImageFormat('rgb')).toBe('image/x-rgb');
+    expect(canonicalizeImageFormat('rgba')).toBe('image/x-rgba');
+    expect(canonicalizeImageFormat('grey')).toBe('image/x-grayscale');
+    expect(canonicalizeImageFormat('cmyk')).toBe('image/x-cmyk');
+  });
+
+  it('infers from channels when the label is unknown / missing', () => {
+    expect(canonicalizeImageFormat(undefined, 1)).toBe('image/x-grayscale');
+    expect(canonicalizeImageFormat('unknown', 3)).toBe('image/x-rgb');
+    expect(canonicalizeImageFormat('', 4)).toBe('image/x-rgba');
+    expect(canonicalizeImageFormat('bin')).toBe('application/octet-stream');
+  });
+});
+
+describe('encodePDFImage (issue #73)', () => {
+  it('encodes raw RGB to WebP by default', async () => {
+    const encoded = await encodePDFImage(makeRawRGBImage());
+
+    expect(encoded.format).toBe('image/webp');
+    const buf = encoded.data as Buffer;
+    expect(buf.subarray(0, 4).toString('ascii')).toBe('RIFF');
+    expect(buf.subarray(8, 12).toString('ascii')).toBe('WEBP');
+    // Encoded outputs deliberately drop `bitsPerComponent` and `channels`
+    // so the buffer cannot be misinterpreted as raw pixel data by OCR
+    // heuristics that key on `width && height && channels`.
+    expect(encoded.bitsPerComponent).toBeUndefined();
+    expect(encoded.channels).toBeUndefined();
+  });
+
+  it('encodes raw RGBA to WebP and preserves alpha-bearing pixels', async () => {
+    const width = 4;
+    const height = 4;
+    const data = Buffer.alloc(width * height * 4);
+    for (let i = 0; i < width * height; i++) {
+      data[i * 4] = 0;
+      data[i * 4 + 1] = 128;
+      data[i * 4 + 2] = 255;
+      data[i * 4 + 3] = 200; // semi-transparent
+    }
+    const rgba: PDFImage = {
+      data,
+      width,
+      height,
+      channels: 4,
+      bitsPerComponent: 8,
+      format: 'image/x-rgba',
+      pageNumber: 1,
+    };
+
+    const encoded = await encodePDFImage(rgba);
+    expect(encoded.format).toBe('image/webp');
+    const buf = encoded.data as Buffer;
+    expect(buf.subarray(0, 4).toString('ascii')).toBe('RIFF');
+    expect(buf.subarray(8, 12).toString('ascii')).toBe('WEBP');
+    expect(encoded.channels).toBeUndefined();
+  });
+
+  it('encodes raw RGB to PNG when requested', async () => {
+    const encoded = await encodePDFImage(makeRawRGBImage(), 'png');
+
+    expect(encoded.format).toBe('image/png');
+    const buf = encoded.data as Buffer;
+    expect(buf[0]).toBe(0x89);
+    expect(buf[1]).toBe(0x50);
+    expect(buf[2]).toBe(0x4e);
+    expect(buf[3]).toBe(0x47);
+  });
+
+  it('encodes raw RGB to JPEG when requested', async () => {
+    const encoded = await encodePDFImage(makeRawRGBImage(8, 8), 'jpeg');
+
+    expect(encoded.format).toBe('image/jpeg');
+    const buf = encoded.data as Buffer;
+    expect(buf[0]).toBe(0xff);
+    expect(buf[1]).toBe(0xd8);
+  });
+
+  it('returns the source unchanged for outputFormat=original (canonicalized format)', async () => {
+    const original = makeRawRGBImage();
+    const encoded = await encodePDFImage(original, 'original');
+
+    expect(encoded.data).toBe(original.data);
+    expect(encoded.format).toBe('image/x-rgb');
+    expect(encoded.bitsPerComponent).toBe(8);
+  });
+
+  it('does not re-encode when source already matches target', async () => {
+    const png = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    const sourceImage: PDFImage = {
+      data: png,
+      width: 1,
+      height: 1,
+      format: 'image/png',
+      pageNumber: 1,
+    };
+
+    const encoded = await encodePDFImage(sourceImage, 'png');
+    expect(encoded.data).toBe(png);
+    expect(encoded.format).toBe('image/png');
+  });
+
+  it('refuses to interpret raw bytes when bitsPerComponent disagrees', async () => {
+    // Length-only inference is unsafe (ocr#75): a 1-channel × 16-bit image
+    // is byte-indistinguishable from a 2-channel × 8-bit image. Mark
+    // bitsPerComponent=16 so the helper takes the safe path: it does not
+    // re-encode and simply canonicalizes the format.
+    const sixteenBit: PDFImage = {
+      data: Buffer.alloc(2 * 2 * 1 * 2), // 2x2 16-bit grayscale
+      width: 2,
+      height: 2,
+      channels: 1,
+      bitsPerComponent: 16,
+      format: 'image/x-grayscale',
+      pageNumber: 1,
+    };
+
+    const encoded = await encodePDFImage(sixteenBit, 'webp');
+    // Helper returned source bytes with canonicalized format rather than
+    // mis-decoding the buffer.
+    expect(encoded.data).toBe(sixteenBit.data);
+    expect(encoded.format).toBe('image/x-grayscale');
+  });
+});

--- a/src/node/image-encoding.test.ts
+++ b/src/node/image-encoding.test.ts
@@ -4,7 +4,10 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { canonicalizeImageFormat } from '../shared/image-format';
+import {
+  canonicalizeImageFormat,
+  detectImageMimeFromMagicBytes,
+} from '../shared/image-format';
 import type { PDFImage } from '../shared/types';
 import { encodePDFImage } from './image-encoding';
 
@@ -51,6 +54,57 @@ describe('canonicalizeImageFormat (issue #74)', () => {
     expect(canonicalizeImageFormat('unknown', 3)).toBe('image/x-rgb');
     expect(canonicalizeImageFormat('', 4)).toBe('image/x-rgba');
     expect(canonicalizeImageFormat('bin')).toBe('application/octet-stream');
+  });
+
+  it('treats application/octet-stream as idempotent (does not re-infer raw mime from channels)', () => {
+    // Regression: when the unpdf provider explicitly sets
+    // `application/octet-stream` for an opaque buffer (byte length does
+    // not match a raw layout), `applyOutputFormat({ outputFormat:
+    // 'original' })` re-runs canonicalizeImageFormat. If channel
+    // inference wins, the final label gets "upgraded" to image/x-rgb
+    // and we re-introduce exactly the issue #74 mis-label this PR fixes.
+    expect(canonicalizeImageFormat('application/octet-stream', 3)).toBe(
+      'application/octet-stream',
+    );
+    expect(canonicalizeImageFormat('application/octet-stream', 4)).toBe(
+      'application/octet-stream',
+    );
+    expect(canonicalizeImageFormat('application/octet-stream', 1)).toBe(
+      'application/octet-stream',
+    );
+  });
+});
+
+describe('detectImageMimeFromMagicBytes', () => {
+  it('detects PNG, JPEG, WebP, and TIFF signatures', () => {
+    const png = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    expect(detectImageMimeFromMagicBytes(png)).toBe('image/png');
+
+    const jpeg = Buffer.from([0xff, 0xd8, 0xff, 0xe0]);
+    expect(detectImageMimeFromMagicBytes(jpeg)).toBe('image/jpeg');
+
+    const webp = Buffer.from([
+      0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50,
+    ]);
+    expect(detectImageMimeFromMagicBytes(webp)).toBe('image/webp');
+
+    const tiffLE = Buffer.from([0x49, 0x49, 0x2a, 0x00]);
+    expect(detectImageMimeFromMagicBytes(tiffLE)).toBe('image/tiff');
+
+    const tiffBE = Buffer.from([0x4d, 0x4d, 0x00, 0x2a]);
+    expect(detectImageMimeFromMagicBytes(tiffBE)).toBe('image/tiff');
+  });
+
+  it('returns undefined for unrecognized / too-short buffers', () => {
+    expect(detectImageMimeFromMagicBytes(Buffer.alloc(0))).toBeUndefined();
+    expect(
+      detectImageMimeFromMagicBytes(Buffer.from([0x00, 0x01, 0x02])),
+    ).toBeUndefined();
+    // RIFF without WEBP — could be a WAV or AVI; not WebP.
+    const riffNotWebp = Buffer.from([
+      0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x41, 0x56, 0x45,
+    ]);
+    expect(detectImageMimeFromMagicBytes(riffNotWebp)).toBeUndefined();
   });
 });
 
@@ -139,6 +193,29 @@ describe('encodePDFImage (issue #73)', () => {
     const encoded = await encodePDFImage(sourceImage, 'png');
     expect(encoded.data).toBe(png);
     expect(encoded.format).toBe('image/png');
+  });
+
+  it('drops raw-pixel metadata in the pass-through (already-encoded) branch', async () => {
+    // If a caller had a JPEG with `channels: 3` set (e.g. inherited from
+    // an earlier raw extraction) and asks for 'jpeg' output, the pass-
+    // through branch should still drop `channels` / `bitsPerComponent`
+    // so OCR providers don't see "encoded buffer + raw-layout metadata".
+    const jpeg = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+    const sourceImage: PDFImage = {
+      data: jpeg,
+      width: 100,
+      height: 100,
+      channels: 3,
+      bitsPerComponent: 8,
+      format: 'image/jpeg',
+      pageNumber: 1,
+    };
+
+    const encoded = await encodePDFImage(sourceImage, 'jpeg');
+    expect(encoded.data).toBe(jpeg);
+    expect(encoded.format).toBe('image/jpeg');
+    expect(encoded.channels).toBeUndefined();
+    expect(encoded.bitsPerComponent).toBeUndefined();
   });
 
   it('refuses to interpret raw bytes when bitsPerComponent disagrees', async () => {

--- a/src/node/image-encoding.ts
+++ b/src/node/image-encoding.ts
@@ -1,0 +1,211 @@
+/**
+ * @happyvertical/pdf - Web-safe re-encoding for extracted PDF images.
+ *
+ * `extractImages` and `renderPages` produce raw pixel buffers (RGB / RGBA /
+ * grayscale) or raw provider streams that downstream consumers cannot store
+ * or render directly. This module re-encodes those buffers to canonical
+ * web-safe formats (WebP / PNG / JPEG) using `@napi-rs/canvas`, the same
+ * canvas dependency we already pull in for `renderPages`.
+ *
+ * See:
+ * - https://github.com/happyvertical/pdf/issues/73 — web-safe output by default.
+ * - https://github.com/happyvertical/pdf/issues/74 — canonical IANA mime types.
+ */
+
+import { Canvas, ImageData } from '@napi-rs/canvas';
+import { canonicalizeImageFormat } from '../shared/image-format';
+import type {
+  ImageEncodingOptions,
+  PDFImage,
+  PDFImageMimeType,
+  PDFImageOutputFormat,
+} from '../shared/types';
+
+export { canonicalizeImageFormat };
+
+const DEFAULT_WEBP_QUALITY = 86;
+const DEFAULT_JPEG_QUALITY = 85;
+
+/** Mime type emitted by the encoder for each web-safe target. */
+const ENCODED_MIME_TYPES: Record<
+  Exclude<PDFImageOutputFormat, 'original'>,
+  PDFImageMimeType
+> = {
+  webp: 'image/webp',
+  png: 'image/png',
+  jpeg: 'image/jpeg',
+};
+
+/**
+ * Whether a `PDFImage` carries raw 8-bit pixel data we can safely re-encode.
+ *
+ * The byte length must match `width * height * channels` exactly — anything
+ * else means the buffer is already encoded (JPEG / PNG / etc.) or that the
+ * stream uses a non-8-bit layout (e.g. 16-bit grayscale) that we don't
+ * recompose without `bitsPerComponent`. See ocr#75 for context on why
+ * length-based inference alone is unsafe.
+ */
+function isRaw8BitPixelImage(image: PDFImage): image is PDFImage & {
+  data: Buffer | Uint8Array;
+  width: number;
+  height: number;
+  channels: 1 | 3 | 4;
+} {
+  if (typeof image.data === 'string') return false;
+  if (!image.width || !image.height) return false;
+  if (image.channels !== 1 && image.channels !== 3 && image.channels !== 4) {
+    return false;
+  }
+
+  const bps = image.bitsPerComponent ?? 8;
+  if (bps !== 8) return false;
+
+  const expectedBytes = image.width * image.height * image.channels;
+  return image.data.byteLength === expectedBytes;
+}
+
+function expandToRGBA(
+  raw: Uint8Array,
+  width: number,
+  height: number,
+  channels: 1 | 3 | 4,
+): Uint8ClampedArray {
+  const pixels = width * height;
+  const rgba = new Uint8ClampedArray(pixels * 4);
+
+  if (channels === 4) {
+    rgba.set(raw);
+    return rgba;
+  }
+
+  if (channels === 3) {
+    for (let i = 0, j = 0; i < pixels; i++) {
+      rgba[j++] = raw[i * 3];
+      rgba[j++] = raw[i * 3 + 1];
+      rgba[j++] = raw[i * 3 + 2];
+      rgba[j++] = 255;
+    }
+    return rgba;
+  }
+
+  // grayscale
+  for (let i = 0, j = 0; i < pixels; i++) {
+    const v = raw[i];
+    rgba[j++] = v;
+    rgba[j++] = v;
+    rgba[j++] = v;
+    rgba[j++] = 255;
+  }
+  return rgba;
+}
+
+/**
+ * Re-encode a `PDFImage` to a web-safe format.
+ *
+ * Returns a new `PDFImage` whose `data` is the encoded buffer and whose
+ * `format` is the canonical IANA mime type of the encoding. When the input
+ * is already an encoded blob (JPEG / PNG / WebP) and matches the requested
+ * target, the original buffer is returned unchanged. When the input cannot
+ * be safely re-encoded (unknown raw layout, no dimensions, etc.) the
+ * original image is returned with a normalized `format`.
+ *
+ * @param image  - PDFImage produced by `extractImages` or `renderPages`.
+ * @param target - Web-safe target format. `'original'` returns the input
+ *                 with only its `format` canonicalized.
+ * @param options - Quality / compression knobs for lossy formats.
+ */
+export async function encodePDFImage(
+  image: PDFImage,
+  target: PDFImageOutputFormat = 'webp',
+  options: ImageEncodingOptions = {},
+): Promise<PDFImage> {
+  const canonicalFormat = canonicalizeImageFormat(image.format, image.channels);
+
+  if (target === 'original') {
+    return { ...image, format: canonicalFormat };
+  }
+
+  const targetMime = ENCODED_MIME_TYPES[target];
+
+  // Pass-through when the source already matches the requested encoding.
+  if (canonicalFormat === targetMime) {
+    return { ...image, format: targetMime };
+  }
+
+  if (!isRaw8BitPixelImage(image)) {
+    // We can't re-encode something that isn't a raw 8-bit pixel buffer.
+    // Hand back the source bytes with the canonical mime so consumers can
+    // route on `format` and fall back to magic-byte detection.
+    return { ...image, format: canonicalFormat };
+  }
+
+  const { width, height, channels } = image;
+  const rawData =
+    image.data instanceof Uint8Array
+      ? image.data
+      : new Uint8Array(image.data as ArrayBuffer);
+  const rgba = expandToRGBA(rawData, width, height, channels);
+
+  const canvas = new Canvas(width, height);
+  const ctx = canvas.getContext('2d');
+  ctx.putImageData(new ImageData(rgba, width, height), 0, 0);
+
+  let encoded: Buffer;
+  if (target === 'png') {
+    encoded = await canvas.encode('png');
+  } else if (target === 'jpeg') {
+    const quality = options.quality ?? DEFAULT_JPEG_QUALITY;
+    encoded = await canvas.encode('jpeg', quality);
+  } else {
+    const quality = options.quality ?? DEFAULT_WEBP_QUALITY;
+    encoded = await canvas.encode('webp', quality);
+  }
+
+  // Help V8 release the canvas-backed pixel buffer eagerly; large pages
+  // can otherwise pin memory across the whole batch.
+  canvas.width = 0;
+  canvas.height = 0;
+
+  // For encoded outputs we deliberately drop `bitsPerComponent` and
+  // `channels` because consumers should decode the encoded stream rather
+  // than reinterpret raw bytes from the dimensions. Dropping `channels`
+  // also defends against OCR providers that use an `(width && height &&
+  // Buffer)` heuristic to take a raw-pixel fast path — without `channels`
+  // the heuristic is more likely to fall through to magic-byte detection.
+  // (Width / height stay set because they are useful metadata for
+  // downstream storage; OCR-on-extracted-images flows should use
+  // `outputFormat: 'original'`.)
+  return {
+    ...image,
+    data: encoded,
+    format: targetMime,
+    bitsPerComponent: undefined,
+    channels: undefined,
+  };
+}
+
+/**
+ * Apply `outputFormat` to a freshly-extracted batch of images.
+ *
+ * Skips encoding entirely when `target` is `'original'` so the hot path
+ * (raw RGB → OCR) stays zero-copy.
+ */
+export async function applyOutputFormat(
+  images: PDFImage[],
+  target: PDFImageOutputFormat,
+  options: ImageEncodingOptions = {},
+): Promise<PDFImage[]> {
+  if (target === 'original') {
+    // Still canonicalize `format` per #74 even when not re-encoding.
+    return images.map((image) => ({
+      ...image,
+      format: canonicalizeImageFormat(image.format, image.channels),
+    }));
+  }
+
+  const encoded: PDFImage[] = [];
+  for (const image of images) {
+    encoded.push(await encodePDFImage(image, target, options));
+  }
+  return encoded;
+}

--- a/src/node/image-encoding.ts
+++ b/src/node/image-encoding.ts
@@ -128,8 +128,16 @@ export async function encodePDFImage(
   const targetMime = ENCODED_MIME_TYPES[target];
 
   // Pass-through when the source already matches the requested encoding.
+  // Even though the bytes are unchanged, the contract for encoded outputs
+  // is that raw-pixel-only metadata is dropped — otherwise consumers /
+  // OCR heuristics may misread an encoded buffer as raw pixel data.
   if (canonicalFormat === targetMime) {
-    return { ...image, format: targetMime };
+    return {
+      ...image,
+      format: targetMime,
+      bitsPerComponent: undefined,
+      channels: undefined,
+    };
   }
 
   if (!isRaw8BitPixelImage(image)) {

--- a/src/node/unpdf.ts
+++ b/src/node/unpdf.ts
@@ -35,7 +35,15 @@ import {
   PDFImageCollectionLimitError,
   PDFOCRFallbackError,
 } from '../shared/types';
+import { applyOutputFormat, canonicalizeImageFormat } from './image-encoding';
 import { formatPdfOcrRuntimeIssue } from './ocr-runtime';
+
+const DEFAULT_EXTRACT_IMAGES_OUTPUT_FORMAT: NonNullable<
+  ExtractImagesOptions['outputFormat']
+> = 'webp';
+const DEFAULT_RENDER_PAGES_OUTPUT_FORMAT: NonNullable<
+  RenderPagesOptions['outputFormat']
+> = 'original';
 
 const require = createRequire(import.meta.url);
 const IMAGE_EXTRACTION_BATCH_SIZE = 4;
@@ -522,29 +530,38 @@ export class UnpdfProvider extends BasePDFReader {
     pageNumber: number,
   ): PDFImage {
     const rawData = this.convertImageDataToBuffer(image.data);
-
-    // Direct RGB data processing - optimal path for OCR
     let processedData: Buffer = rawData;
-    let format = 'unknown';
+    let bitsPerComponent: number | undefined;
 
-    // If we have raw RGB data (3 channels), keep it as raw RGB
-    if (image.channels === 3 && image.width && image.height) {
-      const expectedSize = image.width * image.height * 3;
-      if (rawData.length === expectedSize) {
+    // unpdf normalizes raw pixel streams to 8-bit Uint8ClampedArray with a
+    // matching channel layout. When the byte length confirms the layout,
+    // hand the optimal raw RGB path to OCR.
+    if (
+      image.channels &&
+      image.width &&
+      image.height &&
+      rawData.length === image.width * image.height * image.channels
+    ) {
+      if (image.channels === 3) {
         processedData = this.processRawRGBData(
           rawData,
           image.width,
           image.height,
         );
-        format = 'rgb'; // Mark as raw RGB for OCR to recognize optimal path
       }
+      bitsPerComponent = 8;
     }
+
+    // Canonicalize `format` to a lowercase IANA mime type per #74 so
+    // downstream consumers don't re-implement the same normalizer.
+    const format = canonicalizeImageFormat(undefined, image.channels);
 
     return {
       data: processedData,
       width: image.width,
       height: image.height,
       channels: image.channels,
+      bitsPerComponent,
       format,
       pageNumber,
     };
@@ -623,6 +640,8 @@ export class UnpdfProvider extends BasePDFReader {
     const maxCollectedBytes = this.normalizeMaxCollectedImageBytes(
       options?.maxCollectedBytes,
     );
+    const outputFormat =
+      options?.outputFormat ?? DEFAULT_EXTRACT_IMAGES_OUTPUT_FORMAT;
     const allImages: PDFImage[] = [];
     let collectedBytes = 0;
 
@@ -639,6 +658,16 @@ export class UnpdfProvider extends BasePDFReader {
         const message = error instanceof Error ? error.message : String(error);
         throw new PDFBatchExtractionError(pages, message);
       }
+
+      // Re-encode to the requested web-safe format before any size
+      // accounting so the byte budget reflects what the caller will hold
+      // onto. WebP / JPEG outputs are typically 5-20x smaller than the
+      // raw RGB buffers, so the safety limit becomes more permissive.
+      images = await applyOutputFormat(
+        images,
+        outputFormat,
+        options?.encodingOptions,
+      );
 
       let nextCollectedBytes = collectedBytes;
 
@@ -709,6 +738,8 @@ export class UnpdfProvider extends BasePDFReader {
           document.numPages,
         );
         const images: PDFImage[] = [];
+        const outputFormat =
+          options?.outputFormat ?? DEFAULT_RENDER_PAGES_OUTPUT_FORMAT;
 
         for (const pageNumber of pagesToRender) {
           const page = await document.getPage(pageNumber);
@@ -727,11 +758,12 @@ export class UnpdfProvider extends BasePDFReader {
 
             images.push({
               data: this.rgbaToRgbBuffer(imageData.data),
-              format: 'rgb',
+              format: canonicalizeImageFormat(undefined, 3),
               pageNumber,
               width,
               height,
               channels: 3,
+              bitsPerComponent: 8,
             });
           } finally {
             page.cleanup();
@@ -740,7 +772,11 @@ export class UnpdfProvider extends BasePDFReader {
           }
         }
 
-        return images;
+        return applyOutputFormat(
+          images,
+          outputFormat,
+          options?.encodingOptions,
+        );
       } finally {
         await document.destroy();
       }

--- a/src/node/unpdf.ts
+++ b/src/node/unpdf.ts
@@ -18,6 +18,7 @@ import type {
   TextItem,
 } from 'pdfjs-dist/types/src/display/api';
 import { BasePDFReader } from '../shared/base';
+import { detectImageMimeFromMagicBytes } from '../shared/image-format';
 import type {
   DependencyCheckResult,
   ExtractImagesOptions,
@@ -536,25 +537,36 @@ export class UnpdfProvider extends BasePDFReader {
     // unpdf normalizes raw pixel streams to 8-bit Uint8ClampedArray with a
     // matching channel layout. When the byte length confirms the layout,
     // hand the optimal raw RGB path to OCR.
-    if (
-      image.channels &&
-      image.width &&
-      image.height &&
-      rawData.length === image.width * image.height * image.channels
-    ) {
-      if (image.channels === 3) {
-        processedData = this.processRawRGBData(
-          rawData,
-          image.width,
-          image.height,
-        );
+    const { width, height, channels } = image;
+    const isRawPixelLayout =
+      channels !== undefined &&
+      width !== undefined &&
+      height !== undefined &&
+      rawData.length === width * height * channels;
+
+    if (isRawPixelLayout && width !== undefined && height !== undefined) {
+      if (channels === 3) {
+        processedData = this.processRawRGBData(rawData, width, height);
       }
       bitsPerComponent = 8;
     }
 
-    // Canonicalize `format` to a lowercase IANA mime type per #74 so
-    // downstream consumers don't re-implement the same normalizer.
-    const format = canonicalizeImageFormat(undefined, image.channels);
+    // Canonicalize `format` to a lowercase IANA mime type per #74.
+    //
+    // Priority (per the issue #74 reviewer guidance): infer raw
+    // `image/x-*` *only* when the byte-length check confirms a raw 8-bit
+    // layout. This prevents a raw RGB buffer that happens to start with
+    // a JPEG SOI marker (e.g. pixel value 0xFF 0xD8 0xFF) from being
+    // sniffed as JPEG. When the byte-length disagrees (encoded stream),
+    // sniff magic bytes; if no signature matches, fall back to
+    // application/octet-stream rather than guessing.
+    let format: PDFImage['format'];
+    if (isRawPixelLayout) {
+      format = canonicalizeImageFormat(undefined, image.channels);
+    } else {
+      format =
+        detectImageMimeFromMagicBytes(rawData) ?? 'application/octet-stream';
+    }
 
     return {
       data: processedData,

--- a/src/ocr-integration.test.ts
+++ b/src/ocr-integration.test.ts
@@ -109,8 +109,16 @@ describe.skipIf(process.env.CI === 'true')(
         'Signed-Meeting-Minutes-October-8-2024-Regular-Council-Meeting-1.pdf',
       );
 
-      // Extract embedded images from the PDF using unpdf (modular workflow)
-      const images = await unpdfReader.extractImages(pdfPath);
+      // Extract embedded images from the PDF using unpdf (modular workflow).
+      //
+      // Pass `outputFormat: 'original'` so we keep the raw RGB fast path that
+      // OCR providers expect. The default for extractImages() is now
+      // 'webp' (issue #73) because most callers store the result as a web
+      // asset rather than feeding it back into OCR — consumers of the
+      // OCR-on-extracted-images flow opt into 'original' explicitly.
+      const images = await unpdfReader.extractImages(pdfPath, {
+        outputFormat: 'original',
+      });
 
       // Scanned PDF should have embedded images
       expect(images.length).toBeGreaterThan(0);

--- a/src/shared/image-format.ts
+++ b/src/shared/image-format.ts
@@ -1,0 +1,68 @@
+/**
+ * @happyvertical/pdf - Canonical image format normalization (browser-safe).
+ *
+ * Issue #74: producer-side `format` values vary wildly (`'rgb'`, `'image/jpg'`,
+ * `'image/x-png'`, `'application/octet-stream'`, etc.). This module returns
+ * the canonical lowercase IANA mime type so consumers don't all reinvent the
+ * same normalizer.
+ *
+ * This file deliberately has no Node-only dependencies so it can be
+ * imported from the shared entry point and the browser bundle alike.
+ */
+
+import type { PDFImageMimeType } from './types';
+
+/**
+ * Canonicalize a producer-emitted `format` value to a lowercase IANA mime.
+ *
+ * `channels` is consulted as a fallback for unrecognized labels (raw streams
+ * frequently arrive with `'unknown'` / `''` / `'application/octet-stream'`).
+ */
+export function canonicalizeImageFormat(
+  format: string | undefined,
+  channels?: number,
+): PDFImageMimeType {
+  const value = (format ?? '').trim().toLowerCase().split(';')[0].trim();
+
+  switch (value) {
+    case 'image/jpeg':
+    case 'image/jpg':
+    case 'jpeg':
+    case 'jpg':
+      return 'image/jpeg';
+    case 'image/png':
+    case 'image/x-png':
+    case 'png':
+      return 'image/png';
+    case 'image/webp':
+    case 'webp':
+      return 'image/webp';
+    case 'image/tiff':
+    case 'image/tif':
+    case 'tiff':
+    case 'tif':
+      return 'image/tiff';
+    case 'image/x-rgb':
+    case 'rgb':
+      return 'image/x-rgb';
+    case 'image/x-rgba':
+    case 'rgba':
+      return 'image/x-rgba';
+    case 'image/x-grayscale':
+    case 'grayscale':
+    case 'gray':
+    case 'grey':
+      return 'image/x-grayscale';
+    case 'image/x-cmyk':
+    case 'cmyk':
+      return 'image/x-cmyk';
+    default:
+      // Fall through to channel inference for unknown / empty labels.
+      break;
+  }
+
+  if (channels === 1) return 'image/x-grayscale';
+  if (channels === 3) return 'image/x-rgb';
+  if (channels === 4) return 'image/x-rgba';
+  return 'application/octet-stream';
+}

--- a/src/shared/image-format.ts
+++ b/src/shared/image-format.ts
@@ -56,6 +56,13 @@ export function canonicalizeImageFormat(
     case 'image/x-cmyk':
     case 'cmyk':
       return 'image/x-cmyk';
+    case 'application/octet-stream':
+      // Idempotent: an explicit `application/octet-stream` is a
+      // deliberate "we don't know" / "opaque blob" signal from the
+      // upstream extractor. Don't try to upgrade it to a raw `image/x-*`
+      // mime via channel inference — that's exactly the mis-labelling
+      // pdf#74 (and the PR #75 review) calls out.
+      return 'application/octet-stream';
     default:
       // Fall through to channel inference for unknown / empty labels.
       break;
@@ -65,4 +72,69 @@ export function canonicalizeImageFormat(
   if (channels === 3) return 'image/x-rgb';
   if (channels === 4) return 'image/x-rgba';
   return 'application/octet-stream';
+}
+
+/**
+ * Detect a canonical IANA mime type from a buffer's magic bytes.
+ *
+ * Used to disambiguate buffers from upstream extractors that don't tell
+ * us whether they're raw pixels or an encoded stream (issue #74). When
+ * unpdf returns `channels: 3` plus a buffer that starts with the JPEG
+ * SOI marker, the buffer is JPEG and labelling it `image/x-rgb` would
+ * mis-route downstream consumers.
+ *
+ * Returns `undefined` when no signature matches, so callers can fall
+ * back to channel-based inference.
+ */
+export function detectImageMimeFromMagicBytes(
+  data: Uint8Array | Buffer,
+): PDFImageMimeType | undefined {
+  if (data.byteLength < 4) return undefined;
+
+  // PNG: 89 50 4E 47 0D 0A 1A 0A
+  if (
+    data[0] === 0x89 &&
+    data[1] === 0x50 &&
+    data[2] === 0x4e &&
+    data[3] === 0x47
+  ) {
+    return 'image/png';
+  }
+
+  // JPEG: FF D8 FF
+  if (data[0] === 0xff && data[1] === 0xd8 && data[2] === 0xff) {
+    return 'image/jpeg';
+  }
+
+  // WebP: "RIFF" .... "WEBP"
+  if (
+    data.byteLength >= 12 &&
+    data[0] === 0x52 &&
+    data[1] === 0x49 &&
+    data[2] === 0x46 &&
+    data[3] === 0x46 &&
+    data[8] === 0x57 &&
+    data[9] === 0x45 &&
+    data[10] === 0x42 &&
+    data[11] === 0x50
+  ) {
+    return 'image/webp';
+  }
+
+  // TIFF (little-endian): 49 49 2A 00
+  // TIFF (big-endian):    4D 4D 00 2A
+  if (
+    (data[0] === 0x49 &&
+      data[1] === 0x49 &&
+      data[2] === 0x2a &&
+      data[3] === 0x00) ||
+    (data[0] === 0x4d &&
+      data[1] === 0x4d &&
+      data[2] === 0x00 &&
+      data[3] === 0x2a)
+  ) {
+    return 'image/tiff';
+  }
+
+  return undefined;
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -67,6 +67,17 @@ export interface RenderPagesOptions {
   outputFolder?: string;
   /** Whether to clean up rendered image files after processing */
   cleanupAfter?: boolean;
+  /**
+   * Re-encode rendered pages to a web-safe format.
+   *
+   * Defaults to `'original'` (raw 8-bit RGB pixels) because the OCR pipeline
+   * consumes raw pixel data and re-encoding adds overhead. Pass `'webp'`,
+   * `'png'`, or `'jpeg'` for callers that want to store or serve the
+   * rendered pages.
+   */
+  outputFormat?: PDFImageOutputFormat;
+  /** Encoding options applied when `outputFormat` is not `'original'`. */
+  encodingOptions?: ImageEncodingOptions;
 }
 
 /**
@@ -110,10 +121,73 @@ export interface PDFMetadata {
 
 /**
  * PDF image data that can be used for OCR processing
+ *
+ * The `format` field is set to a canonical lowercase IANA mime type so
+ * downstream consumers do not have to normalize provider-specific values.
+ *
+ * | Source                    | `format`                  |
+ * |---------------------------|---------------------------|
+ * | JPEG image stream         | `image/jpeg`              |
+ * | PNG image stream          | `image/png`               |
+ * | Re-encoded WebP output    | `image/webp`              |
+ * | Raw 8-bit RGB pixels      | `image/x-rgb`             |
+ * | Raw 8-bit RGBA pixels     | `image/x-rgba`            |
+ * | Raw 8-bit grayscale       | `image/x-grayscale`       |
+ * | Raw CMYK pixels           | `image/x-cmyk`            |
+ * | Unknown / unencoded blob  | `application/octet-stream`|
  */
 export interface PDFImage extends BaseOCRImage {
   /** Page number where the image was found (1-based) */
   pageNumber?: number;
+  /**
+   * Bits per channel sample. Common values: 1, 8, 16. Required for
+   * unambiguous decoding of raw pixel buffers, where
+   * `bytes.length === width * height * channels * (bitsPerComponent / 8)`.
+   *
+   * unpdf-extracted raw images are always 8-bit. For encoded outputs
+   * (`image/webp`, `image/png`, `image/jpeg`) this field is left unset
+   * because consumers should decode via the encoded format, not raw bytes.
+   *
+   * Mirrors the field added to `OCRImage` in @happyvertical/ocr (see
+   * https://github.com/happyvertical/ocr/issues/75); declaring it here
+   * keeps it available before the OCR field rolls out to consumers.
+   */
+  bitsPerComponent?: number;
+}
+
+/**
+ * Canonical IANA mime types emitted by `extractImages` / `renderPages`.
+ */
+export type PDFImageMimeType =
+  | 'image/jpeg'
+  | 'image/png'
+  | 'image/webp'
+  | 'image/tiff'
+  | 'image/x-rgb'
+  | 'image/x-rgba'
+  | 'image/x-grayscale'
+  | 'image/x-cmyk'
+  | 'application/octet-stream';
+
+/**
+ * Web-safe re-encoding target for extracted PDF images.
+ *
+ * `'original'` is the escape hatch: the extractor returns the raw stream
+ * (or a normalized raw RGB buffer) without re-encoding, suitable for
+ * downstream OCR pipelines that prefer raw pixel data.
+ */
+export type PDFImageOutputFormat = 'webp' | 'png' | 'jpeg' | 'original';
+
+/**
+ * Encoding options applied when `outputFormat` re-encodes raw image data.
+ *
+ * Defaults are tuned for storing extracted document images as web assets
+ * (small files, visually lossless): WebP quality 86, JPEG quality 85, PNG
+ * uses lossless encoding.
+ */
+export interface ImageEncodingOptions {
+  /** Quality for lossy formats (webp / jpeg). 0-100, default 86 (webp) / 85 (jpeg). */
+  quality?: number;
 }
 
 /**
@@ -159,6 +233,17 @@ export interface ExtractImagesOptions {
    * document's image bytes in memory.
    */
   onBatch?: (batch: PDFImageBatch) => void | Promise<void>;
+  /**
+   * Re-encode each extracted image to a web-safe format before returning it.
+   *
+   * Defaults to `'webp'` so callers can store or serve `image.data` directly
+   * without an external re-encoder. Pass `'original'` to receive the raw
+   * provider stream unchanged (raw RGB / CMYK / JPEG bytes), which is the
+   * lower-overhead path for downstream OCR.
+   */
+  outputFormat?: PDFImageOutputFormat;
+  /** Encoding options applied when `outputFormat` is not `'original'`. */
+  encodingOptions?: ImageEncodingOptions;
 }
 
 // Re-export OCR result type from the OCR package for backward compatibility


### PR DESCRIPTION
Closes #73, closes #74. Companion to happyvertical/ocr#75 (open PR happyvertical/ocr#76).

## Summary

- `extractImages` now accepts `outputFormat: 'webp' | 'png' | 'jpeg' | 'original'` and re-encodes raw image streams via `@napi-rs/canvas` (already a dep — no new deps). Default is `'webp'` so callers can store/serve `image.data` directly.
- `renderPages` accepts the same option; default stays `'original'` so the internal OCR fallback path stays zero-copy.
- `PDFImage.format` is now a canonical lowercase IANA mime type (`image/jpeg`, `image/png`, `image/webp`, `image/tiff`, `image/x-rgb`, `image/x-rgba`, `image/x-grayscale`, `image/x-cmyk`, `application/octet-stream`).
- `PDFImage.bitsPerComponent` is populated on raw outputs (always `8` from unpdf), forward-compatible with happyvertical/ocr#76.
- New exports: `canonicalizeImageFormat` (pure) and `encodePDFImage` (lazy Node-only re-encoder).
- Encoded outputs drop `channels` and `bitsPerComponent` so the buffer cannot be misread as raw pixel data by OCR providers that key on `width && height && channels`. `width`/`height` stay set as metadata.

## Migration

- Callers that consumed raw RGB bytes (`format === 'rgb'`) → pass `outputFormat: 'original'` and check `image.format === 'image/x-rgb'`.
- Callers that re-encoded extracted images downstream (e.g. via `sharp`) → drop the re-encoder; `image.data` is now WebP by default.
- `extractImages(source, { onBatch })` streaming callers receive WebP unless they pass `outputFormat: 'original'`.
- OCR-on-extracted-images flows that fed `extractImages()` → `performOCR()` → pass `outputFormat: 'original'` (raw RGB is the OCR fast path). Internal OCR fallback (`extractText()` / `renderPages()` → OCR) is unaffected.

Full migration notes are in `.changeset/web-safe-image-extraction.md`.

## Notable design decisions

- Default for `extractImages` is `'webp'` (issue #73's preferred design); default for `renderPages` is `'original'` so the OCR hot path stays zero-copy. Verified in `combined.ts` that no internal call site passes raw `extractImages()` output to OCR.
- `bitsPerComponent` is declared on `PDFImage` (not `OCRImage`) so this PR doesn't block on happyvertical/ocr#76 publishing. When that ships and the OCR dep is bumped, both interfaces will declare the same optional field — TypeScript merges cleanly.
- `canonicalizeImageFormat` lives in `src/shared/` (no Node deps) so the shared entry point stays browser-safe; `encodePDFImage` is exposed via `await import('./node/image-encoding')` so importing `@happyvertical/pdf` doesn't pull in `@napi-rs/canvas` until you actually call it.
- The encoder's `isRaw8BitPixelImage` guard is gated on `bitsPerComponent ?? 8 === 8` plus exact `width * height * channels` byte-length match, so it cannot misinterpret a 16-bit grayscale or 2-channel buffer as raw 8-bit (the exact ambiguity ocr#75 calls out). Covered by a unit test.

## Test plan

- [x] `npm test` — 113/113 passing (added 11 new tests).
- [x] `npx tsc --noEmit` — clean.
- [x] `npx biome check src` — clean.
- [x] `npm run build` — clean (8.08 kB index, 3.15 kB lazy image-encoding chunk, 12.40 kB image-format chunk).
- [x] Independent code review pass (1 finding, fixed before push: encoded output now also drops `channels`).
- [x] Round-trip on a real scanned PDF: WebP-encoded extractImages output verified by RIFF/WEBP magic bytes; OCR-on-extracted-images flow with `outputFormat: 'original'` verified end-to-end.