### PR TITLE
feat(pdf): add HTML-to-PDF generation via puppeteer-core

### DIFF
--- a/.changeset/html-to-pdf-generation.md
+++ b/.changeset/html-to-pdf-generation.md
@@ -1,0 +1,10 @@
+---
+"@happyvertical/pdf": minor
+---
+
+Add HTML-to-PDF generation: `renderHtmlToPdf(html, options)` and
+`resolveChromiumExecutablePath()`. The engine is `puppeteer-core` against a
+system Chromium (no browser download, no cosmiconfig/typescript dependency
+chain), imported lazily so consumers never load browser automation code until
+they actually render. Also bumps `@happyvertical/utils` to the current 0.74
+line.

--- a/package.json
+++ b/package.json
@@ -15,11 +15,7 @@
       "pdfjs-dist": "5.4.296"
     }
   },
-  "files": [
-    "dist",
-    "README.md",
-    "LICENSE"
-  ],
+  "files": ["dist", "README.md", "LICENSE"],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com",
     "access": "public"
@@ -57,10 +53,11 @@
   },
   "dependencies": {
     "@happyvertical/ocr": "^0.60.33",
-    "@happyvertical/utils": "^0.71.20",
+    "@happyvertical/utils": "^0.74.6",
     "@napi-rs/canvas": "0.1.99",
     "pdfjs-dist": "5.4.296",
-    "unpdf": "^1.4.0"
+    "unpdf": "^1.4.0",
+    "puppeteer-core": "^25.1.0"
   },
   "optionalDependencies": {
     "@kreuzberg/node": "^4.1.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,16 +13,19 @@ importers:
     dependencies:
       '@happyvertical/ocr':
         specifier: ^0.60.33
-        version: 0.60.33(ws@8.20.0)
+        version: 0.60.33(ws@8.21.0)(zod@3.25.76)
       '@happyvertical/utils':
-        specifier: ^0.71.20
-        version: 0.71.20
+        specifier: ^0.74.6
+        version: 0.74.6
       '@napi-rs/canvas':
         specifier: 0.1.99
         version: 0.1.99
       pdfjs-dist:
         specifier: 5.4.296
         version: 5.4.296
+      puppeteer-core:
+        specifier: ^25.1.0
+        version: 25.1.0
       unpdf:
         specifier: ^1.4.0
         version: 1.4.0(@napi-rs/canvas@0.1.99)
@@ -615,6 +618,10 @@ packages:
     resolution: {integrity: sha512-5ZjBVRX9PyaATk6JLBkUZJnX8gyW76K0HfvQkOsFn1xnSsTHenOBsNDXct6L0HoaSTO4m6WQXoKSe2h/SPvc5A==, tarball: https://npm.pkg.github.com/download/@happyvertical/utils/0.71.20/3ca16b11c6716e9bfc05fec985a4e46c79ebafa3}
     hasBin: true
 
+  '@happyvertical/utils@0.74.6':
+    resolution: {integrity: sha512-L7ok/WCfzMJhAgu9C7e1n+34L2BMQ0yee/+TOdqhjOeU6tQRix285DI63J7eWytQaYKy9Wmgfwxmw2dBwCrMLg==, tarball: https://npm.pkg.github.com/download/@happyvertical/utils/0.74.6/b05cca1b2027f420dcb9e7c8b29bb61f499e9df3}
+    hasBin: true
+
   '@img/sharp-darwin-arm64@0.33.5':
     resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -926,6 +933,16 @@ packages:
 
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
+
+  '@puppeteer/browsers@3.0.4':
+    resolution: {integrity: sha512-HGM8iAmGTf+Y7t0373szVbTmt3d7vPkYL/1bpOkOFO0YUYLgSeuYBCzESklogNPvOBnZ/MRD5f07OkpqH1trtA==}
+    engines: {node: '>=22.12.0'}
+    hasBin: true
+    peerDependencies:
+      proxy-agent: '>=8.0.1'
+    peerDependenciesMeta:
+      proxy-agent:
+        optional: true
 
   '@rollup/pluginutils@5.3.0':
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
@@ -1482,6 +1499,12 @@ packages:
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
 
+  chromium-bidi@16.0.1:
+    resolution: {integrity: sha512-J63PGu/9PpeCwLIcKYyzWP6yaVL5pxuBc0shlYCYM8BaAkmlwiQboXO1iNbOgSDbVklEyYFfNEcHD8oOAWacUA==}
+    engines: {node: '>=20.19.0 <22.0.0 || >=22.12.0'}
+    peerDependencies:
+      devtools-protocol: '*'
+
   ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
     engines: {node: '>=8'}
@@ -1591,6 +1614,9 @@ packages:
 
   detect-node@2.1.0:
     resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
+
+  devtools-protocol@0.0.1624250:
+    resolution: {integrity: sha512-YFAat/lOiIk0ARmBweG+ygrEcbZrq5B9urRyUoeQKp53MlidHXE2TmTbxKcaXoQj7u/aX+jebDO4BW55rs0WwA==}
 
   diff@8.0.2:
     resolution: {integrity: sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==}
@@ -2096,8 +2122,15 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  mitt@3.0.1:
+    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
+
+  modern-tar@0.7.6:
+    resolution: {integrity: sha512-sweCIVXzx1aIGTCdzcMlSZt1h8k5Tmk08VNAuRk3IU28XamGiOH5ypi11g6De2CH7PhYqSSnGy2A/EFhbWnVKg==}
+    engines: {node: '>=18.0.0'}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -2286,6 +2319,10 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  puppeteer-core@25.1.0:
+    resolution: {integrity: sha512-jKzy5y4WG6uNuFbTWgW1D7mqoT9o0nllc/6a1DGF775T1mPmgw3scdFEtEq67yVFikavQmbYq6NLfbTfxHSlqQ==}
+    engines: {node: '>=22.12.0'}
 
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
@@ -2513,6 +2550,9 @@ packages:
     resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
     engines: {node: '>=10'}
 
+  typed-query-selector@2.12.2:
+    resolution: {integrity: sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==}
+
   typescript@5.8.2:
     resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
     engines: {node: '>=14.17'}
@@ -2649,6 +2689,9 @@ packages:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
+  webdriver-bidi-protocol@0.4.2:
+    resolution: {integrity: sha512-VSV+fzfChirL3e7jay2yUC7B4HQCGtEWEg/MSSQbK+qWbqeGlRLlXTzPpYr3XGUvbpDHumWZBJxgesg4N7dbtA==}
+
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
@@ -2686,6 +2729,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -2708,11 +2763,16 @@ packages:
   zlibjs@0.3.1:
     resolution: {integrity: sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==}
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
 snapshots:
 
-  '@anthropic-ai/sdk@0.82.0':
+  '@anthropic-ai/sdk@0.82.0(zod@3.25.76)':
     dependencies:
       json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 3.25.76
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:
@@ -3528,13 +3588,13 @@ snapshots:
       onnxruntime-node: 1.24.3
       sharp: 0.33.5
 
-  '@happyvertical/ai@0.71.20(ws@8.20.0)':
+  '@happyvertical/ai@0.71.20(ws@8.21.0)(zod@3.25.76)':
     dependencies:
-      '@anthropic-ai/sdk': 0.82.0
+      '@anthropic-ai/sdk': 0.82.0(zod@3.25.76)
       '@aws-sdk/client-bedrock-runtime': 3.997.0
       '@google/genai': 1.48.0
       '@happyvertical/utils': 0.71.20
-      openai: 6.33.0(ws@8.20.0)
+      openai: 6.33.0(ws@8.21.0)(zod@3.25.76)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -3544,10 +3604,10 @@ snapshots:
       - ws
       - zod
 
-  '@happyvertical/ocr@0.60.33(ws@8.20.0)':
+  '@happyvertical/ocr@0.60.33(ws@8.21.0)(zod@3.25.76)':
     dependencies:
       '@gutenye/ocr-node': 1.4.8
-      '@happyvertical/ai': 0.71.20(ws@8.20.0)
+      '@happyvertical/ai': 0.71.20(ws@8.21.0)(zod@3.25.76)
       '@happyvertical/utils': 0.71.20
       jpeg-js: 0.4.4
       pngjs: 7.0.0
@@ -3563,6 +3623,13 @@ snapshots:
       - zod
 
   '@happyvertical/utils@0.71.20':
+    dependencies:
+      '@paralleldrive/cuid2': 3.3.0
+      date-fns: 4.1.0
+      pluralize: 8.0.0
+      uuid: 13.0.0
+
+  '@happyvertical/utils@0.74.6':
     dependencies:
       '@paralleldrive/cuid2': 3.3.0
       date-fns: 4.1.0
@@ -3823,6 +3890,11 @@ snapshots:
   '@protobufjs/pool@1.1.0': {}
 
   '@protobufjs/utf8@1.1.0': {}
+
+  '@puppeteer/browsers@3.0.4':
+    dependencies:
+      modern-tar: 0.7.6
+      yargs: 17.7.2
 
   '@rollup/pluginutils@5.3.0(rollup@4.53.3)':
     dependencies:
@@ -4437,6 +4509,12 @@ snapshots:
 
   chardet@2.1.1: {}
 
+  chromium-bidi@16.0.1(devtools-protocol@0.0.1624250):
+    dependencies:
+      devtools-protocol: 0.0.1624250
+      mitt: 3.0.1
+      zod: 3.25.76
+
   ci-info@3.9.0: {}
 
   cliui@8.0.1:
@@ -4538,6 +4616,8 @@ snapshots:
   detect-libc@2.1.2: {}
 
   detect-node@2.1.0: {}
+
+  devtools-protocol@0.0.1624250: {}
 
   diff@8.0.2: {}
 
@@ -5026,12 +5106,16 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  mitt@3.0.1: {}
+
   mlly@1.8.0:
     dependencies:
       acorn: 8.15.0
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.6.1
+
+  modern-tar@0.7.6: {}
 
   mri@1.2.0: {}
 
@@ -5065,9 +5149,10 @@ snapshots:
       global-agent: 3.0.0
       onnxruntime-common: 1.24.3
 
-  openai@6.33.0(ws@8.20.0):
+  openai@6.33.0(ws@8.21.0)(zod@3.25.76):
     optionalDependencies:
-      ws: 8.20.0
+      ws: 8.21.0
+      zod: 3.25.76
 
   opencollective-postinstall@2.0.3: {}
 
@@ -5185,6 +5270,19 @@ snapshots:
       long: 5.3.2
 
   punycode@2.3.1: {}
+
+  puppeteer-core@25.1.0:
+    dependencies:
+      '@puppeteer/browsers': 3.0.4
+      chromium-bidi: 16.0.1(devtools-protocol@0.0.1624250)
+      devtools-protocol: 0.0.1624250
+      typed-query-selector: 2.12.2
+      webdriver-bidi-protocol: 0.4.2
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - proxy-agent
+      - utf-8-validate
 
   quansync@0.2.11: {}
 
@@ -5417,6 +5515,8 @@ snapshots:
 
   type-fest@0.13.1: {}
 
+  typed-query-selector@2.12.2: {}
+
   typescript@5.8.2: {}
 
   typescript@5.9.3: {}
@@ -5517,6 +5617,8 @@ snapshots:
 
   web-streams-polyfill@3.3.3: {}
 
+  webdriver-bidi-protocol@0.4.2: {}
+
   webidl-conversions@3.0.1: {}
 
   whatwg-url@5.0.0:
@@ -5546,6 +5648,8 @@ snapshots:
 
   ws@8.20.0: {}
 
+  ws@8.21.0: {}
+
   y18n@5.0.8: {}
 
   yallist@4.0.0: {}
@@ -5565,3 +5669,5 @@ snapshots:
   yocto-queue@1.2.2: {}
 
   zlibjs@0.3.1: {}
+
+  zod@3.25.76: {}

--- a/src/html-to-pdf.test.ts
+++ b/src/html-to-pdf.test.ts
@@ -1,12 +1,23 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { renderHtmlToPdf, resolveChromiumExecutablePath } from './index';
 
 const chromium = await resolveChromiumExecutablePath();
 
 describe('HTML to PDF rendering', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it('resolves a chromium executable path or undefined', async () => {
     const path = await resolveChromiumExecutablePath();
     expect(path === undefined || typeof path === 'string').toBe(true);
+  });
+
+  it('ignores a stale PUPPETEER_EXECUTABLE_PATH instead of returning it', async () => {
+    vi.stubEnv('PUPPETEER_EXECUTABLE_PATH', '/nonexistent/chromium-binary');
+    const path = await resolveChromiumExecutablePath();
+    // Falls back to probing well-known locations; never reports the bogus path.
+    expect(path).not.toBe('/nonexistent/chromium-binary');
   });
 
   it('fails with a launch error when the executable path is bogus', async () => {

--- a/src/html-to-pdf.test.ts
+++ b/src/html-to-pdf.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { renderHtmlToPdf, resolveChromiumExecutablePath } from './index';
+
+const chromium = await resolveChromiumExecutablePath();
+
+describe('HTML to PDF rendering', () => {
+  it('resolves a chromium executable path or undefined', async () => {
+    const path = await resolveChromiumExecutablePath();
+    expect(path === undefined || typeof path === 'string').toBe(true);
+  });
+
+  it('fails with a launch error when the executable path is bogus', async () => {
+    await expect(
+      renderHtmlToPdf('<p>hi</p>', {
+        executablePath: '/nonexistent/chromium-binary',
+      }),
+    ).rejects.toThrow(/Browser was not found|Failed to launch|ENOENT/);
+  });
+
+  // Render tests need a real Chromium; skip cleanly where none is installed
+  // (mirrors how OCR tests tolerate missing system dependencies).
+  describe.skipIf(!chromium)('with a system chromium', () => {
+    it('renders HTML to a valid PDF document', async () => {
+      const pdf = await renderHtmlToPdf(
+        '<html><body><h1>HTML to PDF</h1><p>render test</p></body></html>',
+        { format: 'Letter' },
+      );
+
+      expect(pdf).toBeInstanceOf(Uint8Array);
+      expect(pdf.length).toBeGreaterThan(1000);
+      // %PDF- magic bytes
+      expect(Array.from(pdf.subarray(0, 5))).toEqual([
+        0x25, 0x50, 0x44, 0x46, 0x2d,
+      ]);
+    });
+
+    it('honors margins and page format options', async () => {
+      const pdf = await renderHtmlToPdf('<p>margins</p>', {
+        format: 'A4',
+        margin: {
+          top: '0.55in',
+          bottom: '0.55in',
+          left: '0.6in',
+          right: '0.6in',
+        },
+        printBackground: true,
+      });
+      expect(pdf.length).toBeGreaterThan(1000);
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,43 @@ export async function encodePDFImage(
   return mod.encodePDFImage(image, target, options);
 }
 
+export type {
+  HtmlToPdfFormat,
+  HtmlToPdfMargin,
+  HtmlToPdfOptions,
+} from './node/html-to-pdf';
+
+/**
+ * Render an HTML document to PDF bytes using a system Chromium.
+ *
+ * Generation counterpart to the extraction providers. See
+ * `src/node/html-to-pdf.ts` for the engine rationale (puppeteer-core, no
+ * config-loader chain) and runtime requirements (a Chromium binary in the
+ * image or `PUPPETEER_EXECUTABLE_PATH`).
+ *
+ * Node-only at runtime: the browser engine is loaded lazily so that importing
+ * `@happyvertical/pdf` never pulls browser automation code until you actually
+ * render.
+ */
+export async function renderHtmlToPdf(
+  html: string,
+  options?: import('./node/html-to-pdf').HtmlToPdfOptions,
+): Promise<Uint8Array> {
+  const mod = await import('./node/html-to-pdf');
+  return mod.renderHtmlToPdf(html, options);
+}
+
+/**
+ * Locate a usable Chromium/Chrome binary (`PUPPETEER_EXECUTABLE_PATH` first,
+ * then well-known install locations). Returns `undefined` when none is found.
+ */
+export async function resolveChromiumExecutablePath(): Promise<
+  string | undefined
+> {
+  const mod = await import('./node/html-to-pdf');
+  return mod.resolveChromiumExecutablePath();
+}
+
 // Legacy compatibility exports for backward compatibility with existing code
 import { getPDFReader, initializeProviders } from './shared/factory';
 

--- a/src/node/html-to-pdf.ts
+++ b/src/node/html-to-pdf.ts
@@ -1,0 +1,187 @@
+/**
+ * @happyvertical/pdf - HTML to PDF rendering.
+ *
+ * Generation counterpart to the extraction providers: renders an HTML string
+ * to PDF bytes using a system Chromium via `puppeteer-core`. Faithful CSS
+ * (fonts, print styles, `@page` rules) needs a real browser engine, so the
+ * engine choice is encapsulated here — consumers depend on this package, not
+ * on a browser automation library.
+ *
+ * Deliberate constraints:
+ * - `puppeteer-core`, not `puppeteer`: no browser download on install and no
+ *   config-file loader (`cosmiconfig`) in the dependency graph. The wrapper's
+ *   cosmiconfig chain declares an optional `typescript` peer that bundlers
+ *   happily inline (~12 MB) and that crashes ESM builds at module load via
+ *   `ts.sys`'s `__filename` probe — the exact failure this module exists to
+ *   make impossible for consumers.
+ * - The engine is imported lazily inside `renderHtmlToPdf`, so importing
+ *   `@happyvertical/pdf` never pulls browser automation code until a caller
+ *   actually renders. Same idiom as the `@napi-rs/canvas` encoder in
+ *   `encodePDFImage`.
+ * - Callers provide the Chromium binary (container image, system install, or
+ *   `PUPPETEER_EXECUTABLE_PATH`). `resolveChromiumExecutablePath` probes the
+ *   common locations; we never download browsers at runtime.
+ */
+
+import { access } from 'node:fs/promises';
+
+/** Paper sizes accepted by Chromium's print-to-PDF. */
+export type HtmlToPdfFormat =
+  | 'Letter'
+  | 'Legal'
+  | 'Tabloid'
+  | 'Ledger'
+  | 'A0'
+  | 'A1'
+  | 'A2'
+  | 'A3'
+  | 'A4'
+  | 'A5'
+  | 'A6';
+
+/** CSS-style page margins, e.g. `{ top: '0.55in' }`. */
+export interface HtmlToPdfMargin {
+  top?: string;
+  bottom?: string;
+  left?: string;
+  right?: string;
+}
+
+export interface HtmlToPdfOptions {
+  /**
+   * Chromium/Chrome binary to launch. Defaults to
+   * `resolveChromiumExecutablePath()`; rendering throws a descriptive error
+   * when no binary can be found.
+   */
+  executablePath?: string;
+  /** Paper format. Ignored when the document's CSS `@page` size wins via `preferCSSPageSize`. */
+  format?: HtmlToPdfFormat;
+  landscape?: boolean;
+  margin?: HtmlToPdfMargin;
+  /** Render CSS backgrounds. Defaults to true — print-accurate output. */
+  printBackground?: boolean;
+  /** Let a CSS `@page` size declared in the document override `format`. Defaults to true. */
+  preferCSSPageSize?: boolean;
+  /** Page scale factor, 0.1–2. */
+  scale?: number;
+  /**
+   * Wait for `document.fonts.ready` before printing so web fonts don't render
+   * as fallbacks. Defaults to true.
+   */
+  waitForFonts?: boolean;
+  /** Browser launch timeout in milliseconds. Defaults to 60_000. */
+  launchTimeoutMs?: number;
+  /**
+   * Extra Chromium launch args. Appended to the container-safe defaults
+   * (`--no-sandbox --disable-setuid-sandbox --disable-dev-shm-usage`).
+   */
+  extraLaunchArgs?: string[];
+}
+
+const DEFAULT_LAUNCH_TIMEOUT_MS = 60_000;
+
+/**
+ * Container-safe launch defaults. Sandboxing is unavailable in most container
+ * runtimes without extra privileges, and /dev/shm is typically too small for
+ * Chromium's default shared memory usage.
+ */
+const DEFAULT_LAUNCH_ARGS = [
+  '--no-sandbox',
+  '--disable-setuid-sandbox',
+  '--disable-dev-shm-usage',
+];
+
+/** Well-known Chromium/Chrome install locations, probed in order. */
+const CHROMIUM_PROBE_PATHS = [
+  '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+  '/Applications/Chromium.app/Contents/MacOS/Chromium',
+  '/usr/bin/chromium',
+  '/usr/bin/chromium-browser',
+  '/usr/bin/google-chrome-stable',
+  '/usr/bin/google-chrome',
+];
+
+/**
+ * Locate a usable Chromium/Chrome binary.
+ *
+ * Honors `PUPPETEER_EXECUTABLE_PATH` first, then probes well-known install
+ * locations. Returns `undefined` when nothing is found so callers can decide
+ * whether that is fatal (`renderHtmlToPdf` treats it as fatal).
+ */
+export async function resolveChromiumExecutablePath(): Promise<
+  string | undefined
+> {
+  const fromEnv = process.env.PUPPETEER_EXECUTABLE_PATH;
+  if (fromEnv) return fromEnv;
+
+  for (const path of CHROMIUM_PROBE_PATHS) {
+    try {
+      await access(path);
+      return path;
+    } catch {
+      // Probe the next well-known location.
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Render an HTML document to PDF bytes.
+ *
+ * Launches Chromium, loads the HTML, waits for fonts (by default), and prints
+ * with print-accurate defaults (backgrounds on, CSS `@page` size respected).
+ * The browser always closes, including on failure.
+ *
+ * @example
+ * ```typescript
+ * import { renderHtmlToPdf } from '@happyvertical/pdf';
+ *
+ * const pdf = await renderHtmlToPdf('<h1>Hello</h1>', {
+ *   format: 'Letter',
+ *   margin: { top: '0.5in', bottom: '0.5in' },
+ * });
+ * await writeFile('hello.pdf', pdf);
+ * ```
+ */
+export async function renderHtmlToPdf(
+  html: string,
+  options: HtmlToPdfOptions = {},
+): Promise<Uint8Array> {
+  const executablePath =
+    options.executablePath ?? (await resolveChromiumExecutablePath());
+  if (!executablePath) {
+    throw new Error(
+      'renderHtmlToPdf: no Chromium/Chrome binary found. Install chromium in ' +
+        'the runtime image (e.g. `apt-get install chromium`) or set ' +
+        'PUPPETEER_EXECUTABLE_PATH / options.executablePath.',
+    );
+  }
+
+  // Lazy: browser automation enters the process only when a caller renders.
+  const { launch } = await import('puppeteer-core');
+
+  const browser = await launch({
+    executablePath,
+    args: [...DEFAULT_LAUNCH_ARGS, ...(options.extraLaunchArgs ?? [])],
+    timeout: options.launchTimeoutMs ?? DEFAULT_LAUNCH_TIMEOUT_MS,
+  });
+
+  try {
+    const page = await browser.newPage();
+    await page.setContent(html, { waitUntil: 'load' });
+    if (options.waitForFonts !== false) {
+      await page.evaluateHandle('document.fonts.ready');
+    }
+    return await page.pdf({
+      format: options.format,
+      landscape: options.landscape,
+      margin: options.margin,
+      preferCSSPageSize: options.preferCSSPageSize !== false,
+      printBackground: options.printBackground !== false,
+      scale: options.scale,
+    });
+  } finally {
+    await browser.close();
+  }
+}

--- a/src/node/html-to-pdf.ts
+++ b/src/node/html-to-pdf.ts
@@ -104,22 +104,26 @@ const CHROMIUM_PROBE_PATHS = [
 /**
  * Locate a usable Chromium/Chrome binary.
  *
- * Honors `PUPPETEER_EXECUTABLE_PATH` first, then probes well-known install
- * locations. Returns `undefined` when nothing is found so callers can decide
- * whether that is fatal (`renderHtmlToPdf` treats it as fatal).
+ * Honors `PUPPETEER_EXECUTABLE_PATH` first — but only when the path actually
+ * exists, so a stale env var degrades to probing the well-known install
+ * locations instead of reporting a binary that will fail at launch. Returns
+ * `undefined` when nothing usable is found so callers can decide whether that
+ * is fatal (`renderHtmlToPdf` treats it as fatal).
  */
 export async function resolveChromiumExecutablePath(): Promise<
   string | undefined
 > {
-  const fromEnv = process.env.PUPPETEER_EXECUTABLE_PATH;
-  if (fromEnv) return fromEnv;
+  const candidates = [
+    process.env.PUPPETEER_EXECUTABLE_PATH,
+    ...CHROMIUM_PROBE_PATHS,
+  ].filter((path): path is string => Boolean(path));
 
-  for (const path of CHROMIUM_PROBE_PATHS) {
+  for (const path of candidates) {
     try {
       await access(path);
       return path;
     } catch {
-      // Probe the next well-known location.
+      // Probe the next candidate.
     }
   }
 
@@ -171,7 +175,11 @@ export async function renderHtmlToPdf(
     const page = await browser.newPage();
     await page.setContent(html, { waitUntil: 'load' });
     if (options.waitForFonts !== false) {
-      await page.evaluateHandle('document.fonts.ready');
+      // Await in-page so no JSHandle is created (nothing to dispose) and no
+      // FontFaceSet value crosses the protocol boundary.
+      await page.evaluate(async () => {
+        await document.fonts.ready;
+      });
     }
     return await page.pdf({
       format: options.format,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -58,6 +58,7 @@ export default defineConfig({
         '@napi-rs/canvas',
         '@kreuzberg/node',
         /^@kreuzberg\//,
+        'puppeteer-core',
 
         // SDK dependencies
         '@happyvertical/utils',


### PR DESCRIPTION
## Why

`@happyvertical/pdf` is the org home for PDF work, but it only *reads* PDFs (extraction, OCR, metadata). Generation has no home, so apps hand-roll it — willgriffin.dev's resume pipeline took a direct `puppeteer` dependency, whose `cosmiconfig → typescript` (optional peer) chain got inlined by Vite (~12 MB) and crashed production routes at module load (`ts.sys` reads `__filename`, which doesn't exist in ESM). The right fix is for this package to own generation, with the engine constraints solved once for every consumer.

## What

- **`renderHtmlToPdf(html, options): Promise<Uint8Array>`** — print-accurate defaults (backgrounds on, `preferCSSPageSize`, `document.fonts.ready` wait), options for format/margins/landscape/scale/launch args.
- **`resolveChromiumExecutablePath()`** — `PUPPETEER_EXECUTABLE_PATH` first, then well-known install locations; clear error when nothing is found (install chromium in the image or set the env var).
- Engine is **`puppeteer-core@25`**: no browser download on install, **no cosmiconfig/typescript anywhere in the graph**, and it's **lazily imported inside the render call** — same idiom as the `@napi-rs/canvas` encoder — so importing this package never loads browser automation code. The `__filename` class of bug becomes structurally impossible for consumers.
- Tests: real render tests (PDF magic bytes, margins/format) that `skipIf` no system Chromium; error-path coverage.
- Housekeeping: `@happyvertical/utils` `^0.71.20 → ^0.74.6` (current org line).
- Changeset: minor.

## Validation

- `pnpm typecheck` / `lint` / `build`: clean.
- `pnpm test`: **122/122 pass** (13 files), including the new render tests against a real Chromium and the full existing suite on the bumped utils.

## First consumer

willgriffin.dev `packages/resume` will drop its direct `puppeteer` dependency and pass this renderer through its existing `pdfRenderer` seam (templates stay app-side, engine lives here). Its AGENTS.md now codifies: all PDF read/extract/generate targets `@happyvertical/pdf`.