### PR TITLE
fix(pdf): stabilize release gating

### DIFF
--- a/.changeset/release-docs-gates.md
+++ b/.changeset/release-docs-gates.md
@@ -1,0 +1,5 @@
+---
+"@happyvertical/pdf": patch
+---
+
+Release the documentation, API reference, and CI gating updates.

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -51,16 +51,60 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          PR_BRANCH="${{ github.event.pull_request.head.ref }}"
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          MERGE_BASE=$(git merge-base "$BASE_SHA" "$HEAD_SHA")
+
+          changeset_count=$(find .changeset -name '*.md' ! -name 'README.md' 2>/dev/null | wc -l)
+          releaseable_commit_count=$(
+            git log "$MERGE_BASE..$HEAD_SHA" --pretty=format:%s --no-merges |
+              grep -Ec '^[a-z]+(\([^)]+\))?!:|^(feat|fix|perf)(\([^)]+\))?:|^chore\(deps\):' ||
+              true
+          )
+          release_sensitive_paths=$(
+            git diff --name-only "$MERGE_BASE..$HEAD_SHA" -- \
+              README.md \
+              docs/api \
+              package.json \
+              pnpm-lock.yaml \
+              scripts/check-generated-api-docs.ts \
+              src \
+              typedoc.json |
+              grep -Ev '(^|/)[^/]+\.(test|spec)\.tsx?$' ||
+              true
+          )
+
           # Skip if PR has 'skip-changeset' label
           PR_NUM="${{ github.event.pull_request.number }}"
           if gh pr view "$PR_NUM" --json labels \
              --jq '.labels[].name' | grep -q 'skip-changeset'; then
+            if [ "$changeset_count" -gt 0 ]; then
+              echo "ERROR: PR has the skip-changeset label and a changeset."
+              echo "Remove the label or delete the changeset so release intent is unambiguous."
+              exit 1
+            fi
+
+            if [ "$releaseable_commit_count" -gt 0 ]; then
+              echo "ERROR: PR has the skip-changeset label but contains releaseable commits."
+              echo "Remove the label, or rewrite the releaseable commits if no release is intended."
+              exit 1
+            fi
+
+            if [ -n "$release_sensitive_paths" ]; then
+              echo "ERROR: PR has the skip-changeset label but changes package or public docs files:"
+              printf '%s\n' "$release_sensitive_paths" | sed 's/^/  /'
+              echo ""
+              echo "Remove the label and use a releaseable PR title or add an explicit changeset."
+              exit 1
+            fi
+
             echo "Skipping changeset check (skip-changeset label present)"
             exit 0
           fi
 
           # Skip if PR is from changeset-release branch (automated version packages PR)
-          PR_BRANCH="${{ github.event.pull_request.head.ref }}"
           if echo "$PR_BRANCH" | grep -q '^changeset-release/'; then
             echo "Skipping changeset check (changesets release PR from $PR_BRANCH)"
             exit 0
@@ -73,7 +117,6 @@ jobs:
           fi
 
           # Skip if PR title starts with 'chore: version packages' or 'chore(release):'
-          PR_TITLE="${{ github.event.pull_request.title }}"
           if echo "$PR_TITLE" | grep -qiE '^chore(\(release\))?:.*version'; then
             echo "Skipping changeset check (version packages PR)"
             exit 0
@@ -97,9 +140,6 @@ jobs:
 
           echo "PR title will not trigger an automatic release on squash merge"
           echo ""
-
-          # Check if changeset files exist (excluding README.md)
-          changeset_count=$(find .changeset -name '*.md' ! -name 'README.md' 2>/dev/null | wc -l)
 
           if [ "$changeset_count" -eq 0 ]; then
             echo "No changeset found"

--- a/src/factory.test.ts
+++ b/src/factory.test.ts
@@ -196,6 +196,92 @@ describe('PDF Factory Tests', () => {
     expect(reader.normalizeSource).toHaveBeenCalledTimes(1);
   });
 
+  it('should map Kreuzberg metadata fields from extracted buffers', async () => {
+    const reader = new KreuzbergProvider() as any;
+
+    reader.loadKreuzberg = vi.fn().mockResolvedValue({
+      extractBytes: vi.fn().mockResolvedValue({
+        metadata: {
+          pageCount: 3,
+          title: 'Quarterly Report',
+          author: 'HappyVertical',
+          creationDate: '2026-01-02T03:04:05.000Z',
+          modificationDate: '2026-01-03T04:05:06.000Z',
+          isEncrypted: true,
+          version: '1.7',
+        },
+      }),
+    });
+
+    await expect(
+      reader.extractMetadata(new Uint8Array([1, 2, 3])),
+    ).resolves.toMatchObject({
+      pageCount: 3,
+      title: 'Quarterly Report',
+      author: 'HappyVertical',
+      encrypted: true,
+      version: '1.7',
+    });
+  });
+
+  it('should report unavailable Kreuzberg dependencies without throwing', async () => {
+    const reader = new KreuzbergProvider() as any;
+
+    reader.loadKreuzberg = vi
+      .fn()
+      .mockRejectedValue(new Error('native module unavailable'));
+
+    await expect(reader.checkDependencies()).resolves.toMatchObject({
+      available: false,
+      error: 'Kreuzberg dependency not available: native module unavailable',
+      details: {
+        kreuzberg: false,
+      },
+    });
+  });
+
+  it('should report Kreuzberg capabilities from dependency checks', async () => {
+    const reader = new KreuzbergProvider({
+      maxFileSize: 64,
+    });
+
+    const depsSpy = vi
+      .spyOn(reader, 'checkDependencies')
+      .mockResolvedValueOnce({
+        available: true,
+        details: {
+          kreuzberg: true,
+          ocrBackend: 'tesseract',
+        },
+      });
+
+    try {
+      await expect(reader.checkCapabilities()).resolves.toMatchObject({
+        canExtractText: true,
+        canExtractMetadata: true,
+        canExtractImages: false,
+        canPerformOCR: true,
+        maxFileSize: 64,
+      });
+    } finally {
+      depsSpy.mockRestore();
+    }
+  });
+
+  it('should reject standalone image and OCR operations for Kreuzberg', async () => {
+    const reader = new KreuzbergProvider();
+
+    await expect(reader.extractImages(Buffer.from('pdf'))).rejects.toThrow(
+      'Kreuzberg handles OCR internally',
+    );
+    await expect(reader.renderPages(Buffer.from('pdf'))).rejects.toThrow(
+      'Kreuzberg handles page rendering internally',
+    );
+    await expect(reader.performOCR([])).rejects.toThrow(
+      'Kreuzberg integrates OCR into extractText',
+    );
+  });
+
   describe('Environment Variable Configuration', () => {
     const originalEnv = process.env;
 


### PR DESCRIPTION
## Summary

- add a patch changeset so the docs/API/gating work from PR #85 gets released
- add targeted Kreuzberg tests to keep function coverage above the publish threshold
- tighten the changeset check so `skip-changeset` cannot bypass release validation for package/public-doc changes or releaseable commits

## Root Cause

PR #85 merged as `test(pdf): gate docs and coverage`, so the auto-changeset script had no releaseable squash commit to derive a bump from. The publish workflow also stopped before publishing because coverage landed just under the function threshold.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm docs:api:check`
- `pnpm build`
- `pnpm test:coverage`
- simulated the new skip-label path guard against PR #85 and confirmed it would have flagged the package/docs changes