### PR TITLE
fix(pdf): render OCR fallback pages as PNG

### DIFF
--- a/.changeset/png-ocr-fallback.md
+++ b/.changeset/png-ocr-fallback.md
@@ -1,0 +1,5 @@
+---
+"@happyvertical/pdf": patch
+---
+
+Render automatic OCR fallback pages as PNG before passing them to OCR providers so image-only PDFs extract text reliably.

--- a/package.json
+++ b/package.json
@@ -15,11 +15,7 @@
       "pdfjs-dist": "5.4.296"
     }
   },
-  "files": [
-    "dist",
-    "README.md",
-    "LICENSE"
-  ],
+  "files": ["dist", "README.md", "LICENSE"],
   "keywords": [
     "pdf",
     "ocr",
@@ -68,7 +64,7 @@
     "prepare": "lefthook install"
   },
   "dependencies": {
-    "@happyvertical/ocr": "^0.60.52",
+    "@happyvertical/ocr": "^0.60.53",
     "@happyvertical/utils": "^0.74.9",
     "@napi-rs/canvas": "0.1.99",
     "marked": "^14.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     dependencies:
       '@happyvertical/ocr':
-        specifier: ^0.60.52
-        version: 0.60.52(ws@8.21.0)(zod@3.25.76)
+        specifier: ^0.60.53
+        version: 0.60.53(ws@8.21.0)(zod@3.25.76)
       '@happyvertical/utils':
         specifier: ^0.74.9
         version: 0.74.9
@@ -637,13 +637,17 @@ packages:
   '@gutenye/ocr-node@1.4.8':
     resolution: {integrity: sha512-Ej6hHQSrBLCY74Qb2rRYZ0v97kp3h1Q8obLdQDM208ft9BOyqj+aUN2yTYQ/1c/BO695OWDgufRSiWiLB92KLw==}
 
-  '@happyvertical/ai@0.74.9':
-    resolution: {integrity: sha512-+u2hikoM9iOF7KBW6xCDwK1hyvsG+UnQB5R2uvUsMlB0AdrwCWPb51wWCcLvIR8GKm/Pnhf6SuAIj8DdcZk+Fw==}
+  '@happyvertical/ai@0.74.10':
+    resolution: {integrity: sha512-IP7VQ3zqTFkweW0WeflWBZORq+K+pLnYgSO5A5rYEOuqKJT2QLRx46A+H537mFhILmUebRk/tAYItte+CARldg==}
     hasBin: true
 
-  '@happyvertical/ocr@0.60.52':
-    resolution: {integrity: sha512-BWv2XPKe2gVFJE5ru+4Am7zk/C6cn5PSKKprq/xbkws+1k6fqXP0WWyYSzQIvxTBaNWb2vHUrsVQ6h8hMt9Dew==}
+  '@happyvertical/ocr@0.60.53':
+    resolution: {integrity: sha512-T+U2OdKR9yWYUISiIyrf/mP2tNmDGQOQtiseqKzBpRiTxjW5I7WNiPPFaVGNj27Ayy4XecCpXasrGz+FICHj2w==}
     engines: {node: '>=24', pnpm: '>=9'}
+
+  '@happyvertical/utils@0.74.10':
+    resolution: {integrity: sha512-tx4nRBx2svOwYAR68iSKTKKJQ0DYGwoUxHrSAeESKu8Zjep6cEqNt6DOTVBddYSlK+XKNIPHK86Qta1zF+UZlw==}
+    hasBin: true
 
   '@happyvertical/utils@0.74.9':
     resolution: {integrity: sha512-mB45yswQtujrIR4vU9cZq108LyuPkCrChMBzXyN8A1Zvcx8/uB/SOXcw0Al2242fKCA/CABXvJ4cnaxps6bjEA==}
@@ -1828,8 +1832,8 @@ packages:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
 
-  google-auth-library@10.7.0:
-    resolution: {integrity: sha512-QpTAbNJ36TliZLx3TTtahR8HG0hN9RllL1e3FymOvQSIKK8JmgV58H924ub2wa2DsS3ANjjP1Aw1N+Ramc8hqQ==}
+  google-auth-library@10.9.0:
+    resolution: {integrity: sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg==}
     engines: {node: '>=18'}
 
   google-logging-utils@1.1.3:
@@ -3573,7 +3577,7 @@ snapshots:
 
   '@google/genai@1.50.1':
     dependencies:
-      google-auth-library: 10.7.0
+      google-auth-library: 10.9.0
       p-retry: 4.6.2
       protobufjs: 7.6.4
       ws: 8.21.0
@@ -3597,12 +3601,12 @@ snapshots:
       onnxruntime-node: 1.27.0
       sharp: 0.33.5
 
-  '@happyvertical/ai@0.74.9(ws@8.21.0)(zod@3.25.76)':
+  '@happyvertical/ai@0.74.10(ws@8.21.0)(zod@3.25.76)':
     dependencies:
       '@anthropic-ai/sdk': 0.90.0(zod@3.25.76)
       '@aws-sdk/client-bedrock-runtime': 3.1034.0
       '@google/genai': 1.50.1
-      '@happyvertical/utils': 0.74.9
+      '@happyvertical/utils': 0.74.10
       openai: 6.34.0(ws@8.21.0)(zod@3.25.76)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
@@ -3612,10 +3616,10 @@ snapshots:
       - ws
       - zod
 
-  '@happyvertical/ocr@0.60.52(ws@8.21.0)(zod@3.25.76)':
+  '@happyvertical/ocr@0.60.53(ws@8.21.0)(zod@3.25.76)':
     dependencies:
       '@gutenye/ocr-node': 1.4.8
-      '@happyvertical/ai': 0.74.9(ws@8.21.0)(zod@3.25.76)
+      '@happyvertical/ai': 0.74.10(ws@8.21.0)(zod@3.25.76)
       '@happyvertical/utils': 0.74.9
       jpeg-js: 0.4.4
       pngjs: 7.0.0
@@ -3628,6 +3632,13 @@ snapshots:
       - utf-8-validate
       - ws
       - zod
+
+  '@happyvertical/utils@0.74.10':
+    dependencies:
+      '@paralleldrive/cuid2': 3.3.0
+      date-fns: 4.4.0
+      pluralize: 8.0.0
+      uuid: 13.0.2
 
   '@happyvertical/utils@0.74.9':
     dependencies:
@@ -4774,7 +4785,7 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
-  google-auth-library@10.7.0:
+  google-auth-library@10.9.0:
     dependencies:
       base64-js: 1.5.1
       ecdsa-sig-formatter: 1.0.11

--- a/src/node/combined.test.ts
+++ b/src/node/combined.test.ts
@@ -350,6 +350,42 @@ describe('CombinedNodeProvider', () => {
     );
   });
 
+  it('renders automatic OCR fallback pages as PNG images', async () => {
+    const reader = new CombinedNodeProvider() as any;
+
+    reader.unpdfProvider = {
+      extractText: vi.fn().mockResolvedValue(''),
+      getInfo: vi.fn().mockResolvedValue({ pageCount: 1 }),
+      renderPages: vi.fn().mockResolvedValue([
+        {
+          data: Buffer.from([1]),
+          format: 'image/png',
+          width: 10,
+          height: 10,
+          pageNumber: 1,
+        },
+      ]),
+    };
+    reader.ocrFactory = {
+      performOCR: vi.fn().mockResolvedValue({
+        text: 'recognized text',
+        confidence: 95,
+      }),
+    };
+
+    await expect(reader.extractText('/tmp/scanned.pdf')).resolves.toBe(
+      'recognized text',
+    );
+    expect(reader.unpdfProvider.renderPages).toHaveBeenCalledWith(
+      '/tmp/scanned.pdf',
+      expect.objectContaining({
+        outputFormat: 'png',
+        scale: 2,
+        throwOnError: true,
+      }),
+    );
+  });
+
   it('throws an explicit OCR fallback error when rendered OCR returns no text', async () => {
     const reader = new CombinedNodeProvider() as any;
 

--- a/src/node/combined.ts
+++ b/src/node/combined.ts
@@ -320,6 +320,9 @@ export class CombinedNodeProvider extends BasePDFReader {
       scale: 2.0,
       throwOnError: true,
       pages,
+      // Tesseract handles encoded images reliably; raw RGB page renders can
+      // produce empty text for image-only PDFs.
+      outputFormat: 'png',
     });
 
     if (!renderedPages.length) {


### PR DESCRIPTION
## Summary

- Render automatic OCR fallback pages as PNG before passing them to OCR providers.
- Add a regression test asserting OCR fallback render calls request PNG output.
- Update `@happyvertical/ocr` to the released `^0.60.53` fix so PDF validation runs against npm, not a local link.

## Root Cause

Image-only Bentley meeting-minutes PDFs rendered as raw RGB page buffers during automatic OCR fallback. The OCR path could return empty text for those raw renders, leaving downstream ingestion with failed extraction and no article-ready minutes.

## Validation

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm docs:api:check`
- `pnpm test:coverage` (14 files, 137 tests passed)
- Bentley May 26, 2026 signed minutes smoke test through `dist/index.js` extracted 8,510 characters and included `Bentley`/`Minutes`.

Note: local Node is `v22.22.3`, while this package now requests `>=24`, so pnpm printed engine warnings during validation.